### PR TITLE
3.2.58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.58
+
+- Convert `getFuelSubTypeList` from `AtsFuelSubType` as static
+
 ## 3.2.57
 
 - Fix `AtsFuelSubType` enum, `getLocaleKey` structure

--- a/lib/src/ats/src/enums/fuel_sub_type.dart
+++ b/lib/src/ats/src/enums/fuel_sub_type.dart
@@ -245,8 +245,10 @@ enum AtsFuelSubType {
     }
   }
 
-  List<AtsFuelSubType> getFuelSubTypeList(String? fuelType) {
+  static List<AtsFuelSubType> getFuelSubTypeList(String? fuelType) {
     if (fuelType == null) return [];
+
+    /// This `fuelType` is the same list of `AtsCfFuelType` enum values
 
     switch (fuelType) {
       case 'DIESEL':

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_models
 description: Layrz API models for Dart/Flutter. This package contains the models used by the Layrz API.
-version: "3.2.57"
+version: "3.2.58"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
This pull request includes updates to the `layrz_models` package, primarily focusing on converting a method to static and updating the package version. Below are the most important changes:

### Method Conversion:

* Converted the `getFuelSubTypeList` method from `AtsFuelSubType` to static in `lib/src/ats/src/enums/fuel_sub_type.dart`. This change allows the method to be called without instantiating the `AtsFuelSubType` class.

### Documentation and Versioning:

* Updated the `CHANGELOG.md` file to reflect the new version 3.2.58 and the conversion of `getFuelSubTypeList` to static.
* Bumped the package version in `pubspec.yaml` from 3.2.57 to 3.2.58.