### PR TITLE
3.2.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.2.59
+- Added `getLocaleKey` in `AtsFuelType`
+
 ## 3.2.58
 
 - Convert `getFuelSubTypeList` from `AtsFuelSubType` as static

--- a/lib/src/ats/src/enums/cf_fuel_type.dart
+++ b/lib/src/ats/src/enums/cf_fuel_type.dart
@@ -40,4 +40,19 @@ enum AtsCfFuelType {
         throw Exception('Invalid FuelType');
     }
   }
+
+  String getLocaleKey() {
+    switch (this) {
+      case AtsCfFuelType.hydrated:
+        return 'ats.cf.fuelType.DIESEL';
+      case AtsCfFuelType.gasolina:
+        return 'ats.cf.fuelType.GASOLINA';
+      case AtsCfFuelType.diesel:
+        return 'ats.cf.fuelType.HYDRATED';
+      case AtsCfFuelType.biodiesel:
+        return 'ats.cf.fuelType.BIODIESEL';
+      default:
+        throw Exception("Unknown AtsFuelSubType");
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_models
 description: Layrz API models for Dart/Flutter. This package contains the models used by the Layrz API.
-version: "3.2.58"
+version: "3.2.59"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
This pull request includes changes to add a new method for retrieving locale keys in the `AtsCfFuelType` enum and updates the package version. The most important changes are summarized below:

### New Method Addition:
* Added `getLocaleKey` method to the `AtsCfFuelType` enum to return locale-specific keys for different fuel types. (`lib/src/ats/src/enums/cf_fuel_type.dart`)

### Version Update:
* Updated the package version to `3.2.59` in `pubspec.yaml`.

### Documentation:
* Added a changelog entry for version `3.2.59` noting the addition of the `getLocaleKey` method. (`CHANGELOG.md`)