### PR TITLE
Update to 3.3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.22
+- Document `AtsPurchaseOrderCategoriesEntity`
+- `height` and `initialHeight` was added in `AtsEntry`
+
 ## 3.3.21
 
 - Modified things on `BleDevice` to works with `layrz_ble` plugin.

--- a/lib/src/ats/ats.freezed.dart
+++ b/lib/src/ats/ats.freezed.dart
@@ -11378,6 +11378,12 @@ mixin _$AtsEntry {
   /// `fuelAnp` is the fuel anp of the entry.
   String? get fuelAnp => throw _privateConstructorUsedError;
 
+  /// `height` represent a sensor height of the tank.
+  double? get height => throw _privateConstructorUsedError;
+
+  /// `initialHeight` represent a sensor height of the tank.
+  double? get initialHeight => throw _privateConstructorUsedError;
+
   /// Serializes this AtsEntry to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 
@@ -11418,7 +11424,9 @@ abstract class $AtsEntryCopyWith<$Res> {
       double? waterLevel,
       double? initialWaterLevel,
       List<AtsVolume> volumeHistory,
-      String? fuelAnp});
+      String? fuelAnp,
+      double? height,
+      double? initialHeight});
 
   $AssetCopyWith<$Res>? get asset;
   $AtsReceptionCopyWith<$Res>? get reception;
@@ -11460,6 +11468,8 @@ class _$AtsEntryCopyWithImpl<$Res, $Val extends AtsEntry>
     Object? initialWaterLevel = freezed,
     Object? volumeHistory = null,
     Object? fuelAnp = freezed,
+    Object? height = freezed,
+    Object? initialHeight = freezed,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -11546,6 +11556,14 @@ class _$AtsEntryCopyWithImpl<$Res, $Val extends AtsEntry>
           ? _value.fuelAnp
           : fuelAnp // ignore: cast_nullable_to_non_nullable
               as String?,
+      height: freezed == height
+          ? _value.height
+          : height // ignore: cast_nullable_to_non_nullable
+              as double?,
+      initialHeight: freezed == initialHeight
+          ? _value.initialHeight
+          : initialHeight // ignore: cast_nullable_to_non_nullable
+              as double?,
     ) as $Val);
   }
 
@@ -11611,7 +11629,9 @@ abstract class _$$AtsEntryImplCopyWith<$Res>
       double? waterLevel,
       double? initialWaterLevel,
       List<AtsVolume> volumeHistory,
-      String? fuelAnp});
+      String? fuelAnp,
+      double? height,
+      double? initialHeight});
 
   @override
   $AssetCopyWith<$Res>? get asset;
@@ -11653,6 +11673,8 @@ class __$$AtsEntryImplCopyWithImpl<$Res>
     Object? initialWaterLevel = freezed,
     Object? volumeHistory = null,
     Object? fuelAnp = freezed,
+    Object? height = freezed,
+    Object? initialHeight = freezed,
   }) {
     return _then(_$AtsEntryImpl(
       id: null == id
@@ -11739,6 +11761,14 @@ class __$$AtsEntryImplCopyWithImpl<$Res>
           ? _value.fuelAnp
           : fuelAnp // ignore: cast_nullable_to_non_nullable
               as String?,
+      height: freezed == height
+          ? _value.height
+          : height // ignore: cast_nullable_to_non_nullable
+              as double?,
+      initialHeight: freezed == initialHeight
+          ? _value.initialHeight
+          : initialHeight // ignore: cast_nullable_to_non_nullable
+              as double?,
     ));
   }
 }
@@ -11771,7 +11801,9 @@ class _$AtsEntryImpl implements _AtsEntry {
       this.waterLevel,
       this.initialWaterLevel,
       final List<AtsVolume> volumeHistory = const [],
-      this.fuelAnp})
+      this.fuelAnp,
+      this.height,
+      this.initialHeight})
       : _receptions = receptions,
         _volumeHistory = volumeHistory;
 
@@ -11885,9 +11917,17 @@ class _$AtsEntryImpl implements _AtsEntry {
   @override
   final String? fuelAnp;
 
+  /// `height` represent a sensor height of the tank.
+  @override
+  final double? height;
+
+  /// `initialHeight` represent a sensor height of the tank.
+  @override
+  final double? initialHeight;
+
   @override
   String toString() {
-    return 'AtsEntry(id: $id, assetId: $assetId, asset: $asset, oldTankLevel: $oldTankLevel, newTankLevel: $newTankLevel, startAt: $startAt, endAt: $endAt, errorPercent: $errorPercent, reception: $reception, receptions: $receptions, isLinked: $isLinked, fuelType: $fuelType, fuelSubtype: $fuelSubtype, temperature: $temperature, initialTemperature: $initialTemperature, density: $density, initialDensity: $initialDensity, waterLevel: $waterLevel, initialWaterLevel: $initialWaterLevel, volumeHistory: $volumeHistory, fuelAnp: $fuelAnp)';
+    return 'AtsEntry(id: $id, assetId: $assetId, asset: $asset, oldTankLevel: $oldTankLevel, newTankLevel: $newTankLevel, startAt: $startAt, endAt: $endAt, errorPercent: $errorPercent, reception: $reception, receptions: $receptions, isLinked: $isLinked, fuelType: $fuelType, fuelSubtype: $fuelSubtype, temperature: $temperature, initialTemperature: $initialTemperature, density: $density, initialDensity: $initialDensity, waterLevel: $waterLevel, initialWaterLevel: $initialWaterLevel, volumeHistory: $volumeHistory, fuelAnp: $fuelAnp, height: $height, initialHeight: $initialHeight)';
   }
 
   @override
@@ -11929,7 +11969,10 @@ class _$AtsEntryImpl implements _AtsEntry {
                 other.initialWaterLevel == initialWaterLevel) &&
             const DeepCollectionEquality()
                 .equals(other._volumeHistory, _volumeHistory) &&
-            (identical(other.fuelAnp, fuelAnp) || other.fuelAnp == fuelAnp));
+            (identical(other.fuelAnp, fuelAnp) || other.fuelAnp == fuelAnp) &&
+            (identical(other.height, height) || other.height == height) &&
+            (identical(other.initialHeight, initialHeight) ||
+                other.initialHeight == initialHeight));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -11956,7 +11999,9 @@ class _$AtsEntryImpl implements _AtsEntry {
         waterLevel,
         initialWaterLevel,
         const DeepCollectionEquality().hash(_volumeHistory),
-        fuelAnp
+        fuelAnp,
+        height,
+        initialHeight
       ]);
 
   /// Create a copy of AtsEntry
@@ -12001,7 +12046,9 @@ abstract class _AtsEntry implements AtsEntry {
       final double? waterLevel,
       final double? initialWaterLevel,
       final List<AtsVolume> volumeHistory,
-      final String? fuelAnp}) = _$AtsEntryImpl;
+      final String? fuelAnp,
+      final double? height,
+      final double? initialHeight}) = _$AtsEntryImpl;
 
   factory _AtsEntry.fromJson(Map<String, dynamic> json) =
       _$AtsEntryImpl.fromJson;
@@ -12095,6 +12142,14 @@ abstract class _AtsEntry implements AtsEntry {
   /// `fuelAnp` is the fuel anp of the entry.
   @override
   String? get fuelAnp;
+
+  /// `height` represent a sensor height of the tank.
+  @override
+  double? get height;
+
+  /// `initialHeight` represent a sensor height of the tank.
+  @override
+  double? get initialHeight;
 
   /// Create a copy of AtsEntry
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/src/ats/ats.g.dart
+++ b/lib/src/ats/ats.g.dart
@@ -973,6 +973,8 @@ _$AtsEntryImpl _$$AtsEntryImplFromJson(Map<String, dynamic> json) =>
               .toList() ??
           const [],
       fuelAnp: json['fuelAnp'] as String?,
+      height: (json['height'] as num?)?.toDouble(),
+      initialHeight: (json['initialHeight'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _$$AtsEntryImplToJson(_$AtsEntryImpl instance) =>
@@ -998,6 +1000,8 @@ Map<String, dynamic> _$$AtsEntryImplToJson(_$AtsEntryImpl instance) =>
       'initialWaterLevel': instance.initialWaterLevel,
       'volumeHistory': instance.volumeHistory.map((e) => e.toJson()).toList(),
       'fuelAnp': instance.fuelAnp,
+      'height': instance.height,
+      'initialHeight': instance.initialHeight,
     };
 
 _$AtsVolumeImpl _$$AtsVolumeImplFromJson(Map<String, dynamic> json) =>

--- a/lib/src/ats/src/entries/entry.dart
+++ b/lib/src/ats/src/entries/entry.dart
@@ -75,6 +75,12 @@ class AtsEntry with _$AtsEntry {
 
     /// `fuelAnp` is the fuel anp of the entry.
     String? fuelAnp,
+
+    /// `height` represent a sensor height of the tank.
+    double? height,
+
+    /// `initialHeight` represent a sensor height of the tank.
+    double? initialHeight,
   }) = _AtsEntry;
 
   /// fromJson creates a new `AtsEntry` from a JSON object.

--- a/lib/src/ats/src/enums/purchase_order_categories_entity.dart
+++ b/lib/src/ats/src/enums/purchase_order_categories_entity.dart
@@ -1,14 +1,23 @@
 part of '../../ats.dart';
 
 enum AtsPurchaseOrderCategoriesEntity {
+  // Fuel puchase from Terminal to Reseller (5652 / 6652)
   pickup,
+  // Fuel puchase from Terminal to Supplier (5653 / 6653)
   pickupToSupplier,
+  // Fuel transfer between terminals in the same company (5659 / 6659)
   transfer,
+  // Fuel delivery to supplier (5656 / 6656)
   deliveryToSupplier,
+  // Fuel delivery to reseller (5655 / 6655)
   deliveryToReseller,
+  // For sale outside (5904)
   forSaleOutside,
+  // Fuel delivery to storage (5663 / 6663)
   deliveryToStorage,
+  // Return of fuel from storage (5664 / 6664)
   returnFromStorage,
+  // Not defined
   notDefined;
 
   String toJson() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_models
 description: Layrz API models for Dart/Flutter. This package contains the models used by the Layrz API.
-version: "3.3.21"
+version: "3.3.22"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
This pull request includes updates to the `AtsEntry` class and the `AtsPurchaseOrderCategoriesEntity` enum, along with corresponding documentation and version updates.

### Updates to `AtsEntry` class:
* Added `height` and `initialHeight` properties to the `AtsEntry` class to represent sensor heights of the tank. This includes updates to various parts of the class and its copy methods. [[1]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bR11381-R11386) [[2]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL11421-R11429) [[3]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bR11471-R11472) [[4]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bR11559-R11566) [[5]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL11614-R11634) [[6]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bR11676-R11677) [[7]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bR11764-R11771) [[8]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL11774-R11806) [[9]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bR11920-R11930) [[10]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL11932-R11975) [[11]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL11959-R12004) [[12]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL12004-R12051) [[13]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bR12146-R12153) [[14]](diffhunk://#diff-d5b0f7a70aed3bddcf31af9684db88e0fc0a706793a67acc9765d7a0a16dc664R976-R977) [[15]](diffhunk://#diff-d5b0f7a70aed3bddcf31af9684db88e0fc0a706793a67acc9765d7a0a16dc664R1003-R1004) [[16]](diffhunk://#diff-d0ef2892231924be4a1c8c7fe9c128ae2ade3d63adaee43a719a9dd71d37fa35R78-R83)

### Updates to `AtsPurchaseOrderCategoriesEntity` enum:
* Added documentation for each enum value to describe different fuel purchase and transfer categories.

### Documentation and version updates:
* Updated `CHANGELOG.md` to document the new `AtsPurchaseOrderCategoriesEntity` and the new properties `height` and `initialHeight` in `AtsEntry`.
* Updated the version in `pubspec.yaml` to `3.3.22`.