### PR TITLE
fix BhsEncodeTrip to pass all test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.3.65
 - Added `atsSendOdometerInExecuteExits` in `ReferenceCategory`.
 - Created `AtsEntryInput`
-- Remove `const` in `BHSEncodedTrip` unfreezed 
+- Removed `const` in `BHSEncodedTrip` unfreezed
 
 ## 3.3.64
 - Added `BHSEncodedTrip` and `BHSEncodedTripInput` models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.3.65
 - Added `atsSendOdometerInExecuteExits` in `ReferenceCategory`.
 - Created `AtsEntryInput`
+- Remove `const` in `BHSEncodedTrip` unfreezed 
 
 ## 3.3.64
 - Added `BHSEncodedTrip` and `BHSEncodedTripInput` models

--- a/lib/src/brickhouse/brickhouse.freezed.dart
+++ b/lib/src/brickhouse/brickhouse.freezed.dart
@@ -3465,7 +3465,7 @@ class __$$BHSEncodedTripImplCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$BHSEncodedTripImpl implements _BHSEncodedTrip {
-  const _$BHSEncodedTripImpl(
+  _$BHSEncodedTripImpl(
       {required this.id,
       required this.assetId,
       required this.encodedPolyline,
@@ -3512,7 +3512,7 @@ class _$BHSEncodedTripImpl implements _BHSEncodedTrip {
 }
 
 abstract class _BHSEncodedTrip implements BHSEncodedTrip {
-  const factory _BHSEncodedTrip(
+  factory _BHSEncodedTrip(
       {required String id,
       required String assetId,
       required String encodedPolyline,

--- a/lib/src/brickhouse/src/encoded_trip.dart
+++ b/lib/src/brickhouse/src/encoded_trip.dart
@@ -20,7 +20,7 @@ part of '../brickhouse.dart';
 /// Unix of creation date.
 @unfreezed
 class BHSEncodedTrip with _$BHSEncodedTrip {
-  const factory BHSEncodedTrip({
+  factory BHSEncodedTrip({
     required String id,
     required String assetId,
     required String encodedPolyline,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_models
 description: Layrz API models for Dart/Flutter. This package contains the models used by the Layrz API.
-version: "3.3.64"
+version: "3.3.65"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
This pull request includes several changes to the `BHSEncodedTrip` class and related files, primarily focusing on removing the `const` keyword and updating the `CHANGELOG.md`. The most important changes are listed below:

### Updates to `BHSEncodedTrip` class:

* Removed the `const` keyword from the `_$BHSEncodedTripImpl` constructor in `lib/src/brickhouse/brickhouse.freezed.dart`.
* Removed the `const` keyword from the `_BHSEncodedTrip` factory constructor in `lib/src/brickhouse/brickhouse.freezed.dart`.
* Removed the `const` keyword from the `BHSEncodedTrip` factory constructor in `lib/src/brickhouse/src/encoded_trip.dart`.

### Documentation updates:

* Updated `CHANGELOG.md` to reflect the removal of `const` in `BHSEncodedTrip`.