### PR TITLE
feat: add thirdPartyStorage sample type and third-party storage field…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.8.5
+
+- Added `thirdPartyStorage` value to `AtsLoadingParamsSample` enum, mapped to `THIRD_PARTY_STORAGE` JSON value.
+- Added `correctionFactor` and `liquidWeight` fields to `AtsLoadingParamsFormInput` model for third-party storage support.
+
 ## 3.8.4
 
 - Added `GqlSubscription` class for composable GraphQL subscription query construction.

--- a/lib/src/ats/ats.freezed.dart
+++ b/lib/src/ats/ats.freezed.dart
@@ -7815,7 +7815,11 @@ mixin _$AtsLoadingParamsFormInput {
  double? get volume20;/// `volume20` Volume at 20
  set volume20(double? value);/// `density20` Density at 20
  double? get density20;/// `density20` Density at 20
- set density20(double? value);/// `destinyInformation` Destiny information only on modality seta
+ set density20(double? value);/// `correctionFactor` Correction factor for third-party storage
+ double? get correctionFactor;/// `correctionFactor` Correction factor for third-party storage
+ set correctionFactor(double? value);/// `liquidWeight` Liquid weight for third-party storage
+ double? get liquidWeight;/// `liquidWeight` Liquid weight for third-party storage
+ set liquidWeight(double? value);/// `destinyInformation` Destiny information only on modality seta
  List<AtsDestinyInformationInput>? get destinyInformation;/// `destinyInformation` Destiny information only on modality seta
  set destinyInformation(List<AtsDestinyInformationInput>? value);
 /// Create a copy of AtsLoadingParamsFormInput
@@ -7832,7 +7836,7 @@ $AtsLoadingParamsFormInputCopyWith<AtsLoadingParamsFormInput> get copyWith => _$
 
 @override
 String toString() {
-  return 'AtsLoadingParamsFormInput(id: $id, formNumber: $formNumber, assetId: $assetId, receptionId: $receptionId, driver: $driver, sampleDensity: $sampleDensity, sampleTemperature: $sampleTemperature, assetTemperature: $assetTemperature, analyzedAt: $analyzedAt, sampleType: $sampleType, fuelSubtype: $fuelSubtype, ambientVolume: $ambientVolume, modality: $modality, inpm: $inpm, initialWeight: $initialWeight, finalWeight: $finalWeight, volume20: $volume20, density20: $density20, destinyInformation: $destinyInformation)';
+  return 'AtsLoadingParamsFormInput(id: $id, formNumber: $formNumber, assetId: $assetId, receptionId: $receptionId, driver: $driver, sampleDensity: $sampleDensity, sampleTemperature: $sampleTemperature, assetTemperature: $assetTemperature, analyzedAt: $analyzedAt, sampleType: $sampleType, fuelSubtype: $fuelSubtype, ambientVolume: $ambientVolume, modality: $modality, inpm: $inpm, initialWeight: $initialWeight, finalWeight: $finalWeight, volume20: $volume20, density20: $density20, correctionFactor: $correctionFactor, liquidWeight: $liquidWeight, destinyInformation: $destinyInformation)';
 }
 
 
@@ -7843,7 +7847,7 @@ abstract mixin class $AtsLoadingParamsFormInputCopyWith<$Res>  {
   factory $AtsLoadingParamsFormInputCopyWith(AtsLoadingParamsFormInput value, $Res Function(AtsLoadingParamsFormInput) _then) = _$AtsLoadingParamsFormInputCopyWithImpl;
 @useResult
 $Res call({
- String? id, String? formNumber, String? assetId, String? receptionId, String? driver, double? sampleDensity, double? sampleTemperature, double? assetTemperature, double? analyzedAt,@AtsLoadingParamsSampleOrNullConverter() AtsLoadingParamsSample? sampleType, String? fuelSubtype, double? ambientVolume,@AtsParamsFormModalityOrNullConverter() ParamsFormModality? modality, double? inpm, double? initialWeight, double? finalWeight, double? volume20, double? density20, List<AtsDestinyInformationInput>? destinyInformation
+ String? id, String? formNumber, String? assetId, String? receptionId, String? driver, double? sampleDensity, double? sampleTemperature, double? assetTemperature, double? analyzedAt,@AtsLoadingParamsSampleOrNullConverter() AtsLoadingParamsSample? sampleType, String? fuelSubtype, double? ambientVolume,@AtsParamsFormModalityOrNullConverter() ParamsFormModality? modality, double? inpm, double? initialWeight, double? finalWeight, double? volume20, double? density20, double? correctionFactor, double? liquidWeight, List<AtsDestinyInformationInput>? destinyInformation
 });
 
 
@@ -7860,7 +7864,7 @@ class _$AtsLoadingParamsFormInputCopyWithImpl<$Res>
 
 /// Create a copy of AtsLoadingParamsFormInput
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? formNumber = freezed,Object? assetId = freezed,Object? receptionId = freezed,Object? driver = freezed,Object? sampleDensity = freezed,Object? sampleTemperature = freezed,Object? assetTemperature = freezed,Object? analyzedAt = freezed,Object? sampleType = freezed,Object? fuelSubtype = freezed,Object? ambientVolume = freezed,Object? modality = freezed,Object? inpm = freezed,Object? initialWeight = freezed,Object? finalWeight = freezed,Object? volume20 = freezed,Object? density20 = freezed,Object? destinyInformation = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? formNumber = freezed,Object? assetId = freezed,Object? receptionId = freezed,Object? driver = freezed,Object? sampleDensity = freezed,Object? sampleTemperature = freezed,Object? assetTemperature = freezed,Object? analyzedAt = freezed,Object? sampleType = freezed,Object? fuelSubtype = freezed,Object? ambientVolume = freezed,Object? modality = freezed,Object? inpm = freezed,Object? initialWeight = freezed,Object? finalWeight = freezed,Object? volume20 = freezed,Object? density20 = freezed,Object? correctionFactor = freezed,Object? liquidWeight = freezed,Object? destinyInformation = freezed,}) {
   return _then(_self.copyWith(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,formNumber: freezed == formNumber ? _self.formNumber : formNumber // ignore: cast_nullable_to_non_nullable
@@ -7880,6 +7884,8 @@ as double?,initialWeight: freezed == initialWeight ? _self.initialWeight : initi
 as double?,finalWeight: freezed == finalWeight ? _self.finalWeight : finalWeight // ignore: cast_nullable_to_non_nullable
 as double?,volume20: freezed == volume20 ? _self.volume20 : volume20 // ignore: cast_nullable_to_non_nullable
 as double?,density20: freezed == density20 ? _self.density20 : density20 // ignore: cast_nullable_to_non_nullable
+as double?,correctionFactor: freezed == correctionFactor ? _self.correctionFactor : correctionFactor // ignore: cast_nullable_to_non_nullable
+as double?,liquidWeight: freezed == liquidWeight ? _self.liquidWeight : liquidWeight // ignore: cast_nullable_to_non_nullable
 as double?,destinyInformation: freezed == destinyInformation ? _self.destinyInformation : destinyInformation // ignore: cast_nullable_to_non_nullable
 as List<AtsDestinyInformationInput>?,
   ));
@@ -7966,10 +7972,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  List<AtsDestinyInformationInput>? destinyInformation)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  double? correctionFactor,  double? liquidWeight,  List<AtsDestinyInformationInput>? destinyInformation)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AtsLoadingParamsFormInput() when $default != null:
-return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.driver,_that.sampleDensity,_that.sampleTemperature,_that.assetTemperature,_that.analyzedAt,_that.sampleType,_that.fuelSubtype,_that.ambientVolume,_that.modality,_that.inpm,_that.initialWeight,_that.finalWeight,_that.volume20,_that.density20,_that.destinyInformation);case _:
+return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.driver,_that.sampleDensity,_that.sampleTemperature,_that.assetTemperature,_that.analyzedAt,_that.sampleType,_that.fuelSubtype,_that.ambientVolume,_that.modality,_that.inpm,_that.initialWeight,_that.finalWeight,_that.volume20,_that.density20,_that.correctionFactor,_that.liquidWeight,_that.destinyInformation);case _:
   return orElse();
 
 }
@@ -7987,10 +7993,10 @@ return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  List<AtsDestinyInformationInput>? destinyInformation)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  double? correctionFactor,  double? liquidWeight,  List<AtsDestinyInformationInput>? destinyInformation)  $default,) {final _that = this;
 switch (_that) {
 case _AtsLoadingParamsFormInput():
-return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.driver,_that.sampleDensity,_that.sampleTemperature,_that.assetTemperature,_that.analyzedAt,_that.sampleType,_that.fuelSubtype,_that.ambientVolume,_that.modality,_that.inpm,_that.initialWeight,_that.finalWeight,_that.volume20,_that.density20,_that.destinyInformation);case _:
+return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.driver,_that.sampleDensity,_that.sampleTemperature,_that.assetTemperature,_that.analyzedAt,_that.sampleType,_that.fuelSubtype,_that.ambientVolume,_that.modality,_that.inpm,_that.initialWeight,_that.finalWeight,_that.volume20,_that.density20,_that.correctionFactor,_that.liquidWeight,_that.destinyInformation);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -8007,10 +8013,10 @@ return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  List<AtsDestinyInformationInput>? destinyInformation)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  double? correctionFactor,  double? liquidWeight,  List<AtsDestinyInformationInput>? destinyInformation)?  $default,) {final _that = this;
 switch (_that) {
 case _AtsLoadingParamsFormInput() when $default != null:
-return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.driver,_that.sampleDensity,_that.sampleTemperature,_that.assetTemperature,_that.analyzedAt,_that.sampleType,_that.fuelSubtype,_that.ambientVolume,_that.modality,_that.inpm,_that.initialWeight,_that.finalWeight,_that.volume20,_that.density20,_that.destinyInformation);case _:
+return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.driver,_that.sampleDensity,_that.sampleTemperature,_that.assetTemperature,_that.analyzedAt,_that.sampleType,_that.fuelSubtype,_that.ambientVolume,_that.modality,_that.inpm,_that.initialWeight,_that.finalWeight,_that.volume20,_that.density20,_that.correctionFactor,_that.liquidWeight,_that.destinyInformation);case _:
   return null;
 
 }
@@ -8022,7 +8028,7 @@ return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.
 @JsonSerializable()
 
 class _AtsLoadingParamsFormInput implements AtsLoadingParamsFormInput {
-   _AtsLoadingParamsFormInput({this.id, this.formNumber, this.assetId, this.receptionId, this.driver, this.sampleDensity, this.sampleTemperature, this.assetTemperature, this.analyzedAt, @AtsLoadingParamsSampleOrNullConverter() this.sampleType, this.fuelSubtype, this.ambientVolume, @AtsParamsFormModalityOrNullConverter() this.modality, this.inpm, this.initialWeight, this.finalWeight, this.volume20, this.density20, this.destinyInformation});
+   _AtsLoadingParamsFormInput({this.id, this.formNumber, this.assetId, this.receptionId, this.driver, this.sampleDensity, this.sampleTemperature, this.assetTemperature, this.analyzedAt, @AtsLoadingParamsSampleOrNullConverter() this.sampleType, this.fuelSubtype, this.ambientVolume, @AtsParamsFormModalityOrNullConverter() this.modality, this.inpm, this.initialWeight, this.finalWeight, this.volume20, this.density20, this.correctionFactor, this.liquidWeight, this.destinyInformation});
   factory _AtsLoadingParamsFormInput.fromJson(Map<String, dynamic> json) => _$AtsLoadingParamsFormInputFromJson(json);
 
 /// `id` of the loading params form, ignore it if you are using "addLoadingParams" mutation
@@ -8061,6 +8067,10 @@ class _AtsLoadingParamsFormInput implements AtsLoadingParamsFormInput {
 @override  double? volume20;
 /// `density20` Density at 20
 @override  double? density20;
+/// `correctionFactor` Correction factor for third-party storage
+@override  double? correctionFactor;
+/// `liquidWeight` Liquid weight for third-party storage
+@override  double? liquidWeight;
 /// `destinyInformation` Destiny information only on modality seta
 @override  List<AtsDestinyInformationInput>? destinyInformation;
 
@@ -8079,7 +8089,7 @@ Map<String, dynamic> toJson() {
 
 @override
 String toString() {
-  return 'AtsLoadingParamsFormInput(id: $id, formNumber: $formNumber, assetId: $assetId, receptionId: $receptionId, driver: $driver, sampleDensity: $sampleDensity, sampleTemperature: $sampleTemperature, assetTemperature: $assetTemperature, analyzedAt: $analyzedAt, sampleType: $sampleType, fuelSubtype: $fuelSubtype, ambientVolume: $ambientVolume, modality: $modality, inpm: $inpm, initialWeight: $initialWeight, finalWeight: $finalWeight, volume20: $volume20, density20: $density20, destinyInformation: $destinyInformation)';
+  return 'AtsLoadingParamsFormInput(id: $id, formNumber: $formNumber, assetId: $assetId, receptionId: $receptionId, driver: $driver, sampleDensity: $sampleDensity, sampleTemperature: $sampleTemperature, assetTemperature: $assetTemperature, analyzedAt: $analyzedAt, sampleType: $sampleType, fuelSubtype: $fuelSubtype, ambientVolume: $ambientVolume, modality: $modality, inpm: $inpm, initialWeight: $initialWeight, finalWeight: $finalWeight, volume20: $volume20, density20: $density20, correctionFactor: $correctionFactor, liquidWeight: $liquidWeight, destinyInformation: $destinyInformation)';
 }
 
 
@@ -8090,7 +8100,7 @@ abstract mixin class _$AtsLoadingParamsFormInputCopyWith<$Res> implements $AtsLo
   factory _$AtsLoadingParamsFormInputCopyWith(_AtsLoadingParamsFormInput value, $Res Function(_AtsLoadingParamsFormInput) _then) = __$AtsLoadingParamsFormInputCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, String? formNumber, String? assetId, String? receptionId, String? driver, double? sampleDensity, double? sampleTemperature, double? assetTemperature, double? analyzedAt,@AtsLoadingParamsSampleOrNullConverter() AtsLoadingParamsSample? sampleType, String? fuelSubtype, double? ambientVolume,@AtsParamsFormModalityOrNullConverter() ParamsFormModality? modality, double? inpm, double? initialWeight, double? finalWeight, double? volume20, double? density20, List<AtsDestinyInformationInput>? destinyInformation
+ String? id, String? formNumber, String? assetId, String? receptionId, String? driver, double? sampleDensity, double? sampleTemperature, double? assetTemperature, double? analyzedAt,@AtsLoadingParamsSampleOrNullConverter() AtsLoadingParamsSample? sampleType, String? fuelSubtype, double? ambientVolume,@AtsParamsFormModalityOrNullConverter() ParamsFormModality? modality, double? inpm, double? initialWeight, double? finalWeight, double? volume20, double? density20, double? correctionFactor, double? liquidWeight, List<AtsDestinyInformationInput>? destinyInformation
 });
 
 
@@ -8107,7 +8117,7 @@ class __$AtsLoadingParamsFormInputCopyWithImpl<$Res>
 
 /// Create a copy of AtsLoadingParamsFormInput
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? formNumber = freezed,Object? assetId = freezed,Object? receptionId = freezed,Object? driver = freezed,Object? sampleDensity = freezed,Object? sampleTemperature = freezed,Object? assetTemperature = freezed,Object? analyzedAt = freezed,Object? sampleType = freezed,Object? fuelSubtype = freezed,Object? ambientVolume = freezed,Object? modality = freezed,Object? inpm = freezed,Object? initialWeight = freezed,Object? finalWeight = freezed,Object? volume20 = freezed,Object? density20 = freezed,Object? destinyInformation = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? formNumber = freezed,Object? assetId = freezed,Object? receptionId = freezed,Object? driver = freezed,Object? sampleDensity = freezed,Object? sampleTemperature = freezed,Object? assetTemperature = freezed,Object? analyzedAt = freezed,Object? sampleType = freezed,Object? fuelSubtype = freezed,Object? ambientVolume = freezed,Object? modality = freezed,Object? inpm = freezed,Object? initialWeight = freezed,Object? finalWeight = freezed,Object? volume20 = freezed,Object? density20 = freezed,Object? correctionFactor = freezed,Object? liquidWeight = freezed,Object? destinyInformation = freezed,}) {
   return _then(_AtsLoadingParamsFormInput(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,formNumber: freezed == formNumber ? _self.formNumber : formNumber // ignore: cast_nullable_to_non_nullable
@@ -8127,6 +8137,8 @@ as double?,initialWeight: freezed == initialWeight ? _self.initialWeight : initi
 as double?,finalWeight: freezed == finalWeight ? _self.finalWeight : finalWeight // ignore: cast_nullable_to_non_nullable
 as double?,volume20: freezed == volume20 ? _self.volume20 : volume20 // ignore: cast_nullable_to_non_nullable
 as double?,density20: freezed == density20 ? _self.density20 : density20 // ignore: cast_nullable_to_non_nullable
+as double?,correctionFactor: freezed == correctionFactor ? _self.correctionFactor : correctionFactor // ignore: cast_nullable_to_non_nullable
+as double?,liquidWeight: freezed == liquidWeight ? _self.liquidWeight : liquidWeight // ignore: cast_nullable_to_non_nullable
 as double?,destinyInformation: freezed == destinyInformation ? _self.destinyInformation : destinyInformation // ignore: cast_nullable_to_non_nullable
 as List<AtsDestinyInformationInput>?,
   ));

--- a/lib/src/ats/ats.g.dart
+++ b/lib/src/ats/ats.g.dart
@@ -862,6 +862,8 @@ _AtsLoadingParamsFormInput _$AtsLoadingParamsFormInputFromJson(
   finalWeight: (json['finalWeight'] as num?)?.toDouble(),
   volume20: (json['volume20'] as num?)?.toDouble(),
   density20: (json['density20'] as num?)?.toDouble(),
+  correctionFactor: (json['correctionFactor'] as num?)?.toDouble(),
+  liquidWeight: (json['liquidWeight'] as num?)?.toDouble(),
   destinyInformation: (json['destinyInformation'] as List<dynamic>?)
       ?.map(
         (e) => AtsDestinyInformationInput.fromJson(e as Map<String, dynamic>),
@@ -894,6 +896,8 @@ Map<String, dynamic> _$AtsLoadingParamsFormInputToJson(
   'finalWeight': instance.finalWeight,
   'volume20': instance.volume20,
   'density20': instance.density20,
+  'correctionFactor': instance.correctionFactor,
+  'liquidWeight': instance.liquidWeight,
   'destinyInformation': instance.destinyInformation
       ?.map((e) => e.toJson())
       .toList(),

--- a/lib/src/ats/src/enums/loading_params_sample.dart
+++ b/lib/src/ats/src/enums/loading_params_sample.dart
@@ -3,6 +3,7 @@ part of '../../ats.dart';
 enum AtsLoadingParamsSample {
   sealedSample,
   inSiteSample,
+  thirdPartyStorage,
   unknown,
   ;
 
@@ -12,6 +13,8 @@ enum AtsLoadingParamsSample {
         return 'SEALED_SAMPLE';
       case AtsLoadingParamsSample.inSiteSample:
         return 'IN_SITE_SAMPLE';
+      case AtsLoadingParamsSample.thirdPartyStorage:
+        return 'THIRD_PARTY_STORAGE';
       default:
         return 'UNKNOWN';
     }
@@ -23,6 +26,8 @@ enum AtsLoadingParamsSample {
         return AtsLoadingParamsSample.sealedSample;
       case 'IN_SITE_SAMPLE':
         return AtsLoadingParamsSample.inSiteSample;
+      case 'THIRD_PARTY_STORAGE':
+        return AtsLoadingParamsSample.thirdPartyStorage;
       default:
         return AtsLoadingParamsSample.unknown;
     }
@@ -34,6 +39,8 @@ enum AtsLoadingParamsSample {
         return 'ats.loadingParamsSample.sealedSample';
       case AtsLoadingParamsSample.inSiteSample:
         return 'ats.loadingParamsSample.inSiteSample';
+      case AtsLoadingParamsSample.thirdPartyStorage:
+        return 'ats.loadingParamsSample.thirdPartyStorage';
       default:
         return 'ats.loadingParamsSample.unknown';
     }

--- a/lib/src/ats/src/reception/loading_params_form_input.dart
+++ b/lib/src/ats/src/reception/loading_params_form_input.dart
@@ -57,6 +57,12 @@ abstract class AtsLoadingParamsFormInput with _$AtsLoadingParamsFormInput {
     /// `density20` Density at 20
     double? density20,
 
+    /// `correctionFactor` Correction factor for third-party storage
+    double? correctionFactor,
+
+    /// `liquidWeight` Liquid weight for third-party storage
+    double? liquidWeight,
+
     /// `destinyInformation` Destiny information only on modality seta
     List<AtsDestinyInformationInput>? destinyInformation,
   }) = _AtsLoadingParamsFormInput;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.8.4"
+version: "3.8.5"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
…s to ATS loading params

- Add `thirdPartyStorage` value to `AtsLoadingParamsSample` enum mapped to `THIRD_PARTY_STORAGE`
- Add `correctionFactor` and `liquidWeight` fields to `AtsLoadingParamsFormInput`
- Bump version to 3.8.5