### PR TITLE
fix: InboundService fixes to match backend logic

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.41.8",
+  "flutter": "3.41.9",
   "flavors": {}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.8.12
+
+- Made `position` field nullable (`InboundPositionStructure?`) in `InboundStructure` and `InboundStructureInput` to support services without a position structure.
+- Added `DynamicMapConverter` and `DynamicMapConverterNullable` converters to safely deserialize `Map<dynamic, dynamic>` (e.g. Dart literal `{}`) into `Map<String, dynamic>`.
+- Applied `@DynamicMapConverterNullable()` to `InboundService.credentials` and `@DynamicMapConverter()` to `InboundServiceInput.credentials` to fix deserialization failures when credentials arrive as an empty map literal.
+
 ## 3.8.11
 
 - Adjustments on `Model`, now `widget` is `List<RenderWidget>` instead of plain `RenderWidget`.

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,3 +1,5 @@
 description: This file stores settings for Dart & Flutter DevTools.
 documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
 extensions:
+  - drift: false
+  - shared_preferences: false

--- a/lib/src/builder/builder.freezed.dart
+++ b/lib/src/builder/builder.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$InboundStructure {
 
- bool get hasPosition; InboundPositionStructure get position; bool get hasPayload; List<InboundPayloadStructure> get payload;
+ bool get hasPosition; InboundPositionStructure? get position; bool get hasPayload; List<InboundPayloadStructure> get payload;
 /// Create a copy of InboundStructure
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,11 +48,11 @@ abstract mixin class $InboundStructureCopyWith<$Res>  {
   factory $InboundStructureCopyWith(InboundStructure value, $Res Function(InboundStructure) _then) = _$InboundStructureCopyWithImpl;
 @useResult
 $Res call({
- bool hasPosition, InboundPositionStructure position, bool hasPayload, List<InboundPayloadStructure> payload
+ bool hasPosition, InboundPositionStructure? position, bool hasPayload, List<InboundPayloadStructure> payload
 });
 
 
-$InboundPositionStructureCopyWith<$Res> get position;
+$InboundPositionStructureCopyWith<$Res>? get position;
 
 }
 /// @nodoc
@@ -65,11 +65,11 @@ class _$InboundStructureCopyWithImpl<$Res>
 
 /// Create a copy of InboundStructure
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? hasPosition = null,Object? position = null,Object? hasPayload = null,Object? payload = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? hasPosition = null,Object? position = freezed,Object? hasPayload = null,Object? payload = null,}) {
   return _then(_self.copyWith(
 hasPosition: null == hasPosition ? _self.hasPosition : hasPosition // ignore: cast_nullable_to_non_nullable
-as bool,position: null == position ? _self.position : position // ignore: cast_nullable_to_non_nullable
-as InboundPositionStructure,hasPayload: null == hasPayload ? _self.hasPayload : hasPayload // ignore: cast_nullable_to_non_nullable
+as bool,position: freezed == position ? _self.position : position // ignore: cast_nullable_to_non_nullable
+as InboundPositionStructure?,hasPayload: null == hasPayload ? _self.hasPayload : hasPayload // ignore: cast_nullable_to_non_nullable
 as bool,payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
 as List<InboundPayloadStructure>,
   ));
@@ -78,9 +78,12 @@ as List<InboundPayloadStructure>,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$InboundPositionStructureCopyWith<$Res> get position {
-  
-  return $InboundPositionStructureCopyWith<$Res>(_self.position, (value) {
+$InboundPositionStructureCopyWith<$Res>? get position {
+    if (_self.position == null) {
+    return null;
+  }
+
+  return $InboundPositionStructureCopyWith<$Res>(_self.position!, (value) {
     return _then(_self.copyWith(position: value));
   });
 }
@@ -165,7 +168,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool hasPosition,  InboundPositionStructure position,  bool hasPayload,  List<InboundPayloadStructure> payload)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool hasPosition,  InboundPositionStructure? position,  bool hasPayload,  List<InboundPayloadStructure> payload)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _InboundStructure() when $default != null:
 return $default(_that.hasPosition,_that.position,_that.hasPayload,_that.payload);case _:
@@ -186,7 +189,7 @@ return $default(_that.hasPosition,_that.position,_that.hasPayload,_that.payload)
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool hasPosition,  InboundPositionStructure position,  bool hasPayload,  List<InboundPayloadStructure> payload)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool hasPosition,  InboundPositionStructure? position,  bool hasPayload,  List<InboundPayloadStructure> payload)  $default,) {final _that = this;
 switch (_that) {
 case _InboundStructure():
 return $default(_that.hasPosition,_that.position,_that.hasPayload,_that.payload);case _:
@@ -206,7 +209,7 @@ return $default(_that.hasPosition,_that.position,_that.hasPayload,_that.payload)
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool hasPosition,  InboundPositionStructure position,  bool hasPayload,  List<InboundPayloadStructure> payload)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool hasPosition,  InboundPositionStructure? position,  bool hasPayload,  List<InboundPayloadStructure> payload)?  $default,) {final _that = this;
 switch (_that) {
 case _InboundStructure() when $default != null:
 return $default(_that.hasPosition,_that.position,_that.hasPayload,_that.payload);case _:
@@ -225,7 +228,7 @@ class _InboundStructure implements InboundStructure {
   factory _InboundStructure.fromJson(Map<String, dynamic> json) => _$InboundStructureFromJson(json);
 
 @override final  bool hasPosition;
-@override final  InboundPositionStructure position;
+@override final  InboundPositionStructure? position;
 @override final  bool hasPayload;
  final  List<InboundPayloadStructure> _payload;
 @override List<InboundPayloadStructure> get payload {
@@ -268,11 +271,11 @@ abstract mixin class _$InboundStructureCopyWith<$Res> implements $InboundStructu
   factory _$InboundStructureCopyWith(_InboundStructure value, $Res Function(_InboundStructure) _then) = __$InboundStructureCopyWithImpl;
 @override @useResult
 $Res call({
- bool hasPosition, InboundPositionStructure position, bool hasPayload, List<InboundPayloadStructure> payload
+ bool hasPosition, InboundPositionStructure? position, bool hasPayload, List<InboundPayloadStructure> payload
 });
 
 
-@override $InboundPositionStructureCopyWith<$Res> get position;
+@override $InboundPositionStructureCopyWith<$Res>? get position;
 
 }
 /// @nodoc
@@ -285,11 +288,11 @@ class __$InboundStructureCopyWithImpl<$Res>
 
 /// Create a copy of InboundStructure
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? hasPosition = null,Object? position = null,Object? hasPayload = null,Object? payload = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? hasPosition = null,Object? position = freezed,Object? hasPayload = null,Object? payload = null,}) {
   return _then(_InboundStructure(
 hasPosition: null == hasPosition ? _self.hasPosition : hasPosition // ignore: cast_nullable_to_non_nullable
-as bool,position: null == position ? _self.position : position // ignore: cast_nullable_to_non_nullable
-as InboundPositionStructure,hasPayload: null == hasPayload ? _self.hasPayload : hasPayload // ignore: cast_nullable_to_non_nullable
+as bool,position: freezed == position ? _self.position : position // ignore: cast_nullable_to_non_nullable
+as InboundPositionStructure?,hasPayload: null == hasPayload ? _self.hasPayload : hasPayload // ignore: cast_nullable_to_non_nullable
 as bool,payload: null == payload ? _self._payload : payload // ignore: cast_nullable_to_non_nullable
 as List<InboundPayloadStructure>,
   ));
@@ -299,9 +302,12 @@ as List<InboundPayloadStructure>,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$InboundPositionStructureCopyWith<$Res> get position {
-  
-  return $InboundPositionStructureCopyWith<$Res>(_self.position, (value) {
+$InboundPositionStructureCopyWith<$Res>? get position {
+    if (_self.position == null) {
+    return null;
+  }
+
+  return $InboundPositionStructureCopyWith<$Res>(_self.position!, (value) {
     return _then(_self.copyWith(position: value));
   });
 }
@@ -314,8 +320,8 @@ mixin _$InboundStructureInput {
 /// [hasPosition] defines if the structure has a position.
  bool get hasPosition;/// [hasPosition] defines if the structure has a position.
  set hasPosition(bool value);/// [position] defines the structure of the position.
- InboundPositionStructureInput get position;/// [position] defines the structure of the position.
- set position(InboundPositionStructureInput value);/// [hasPayload] defines if the structure has a payload.
+ InboundPositionStructureInput? get position;/// [position] defines the structure of the position.
+ set position(InboundPositionStructureInput? value);/// [hasPayload] defines if the structure has a payload.
  bool get hasPayload;/// [hasPayload] defines if the structure has a payload.
  set hasPayload(bool value);/// [payload] defines the structure of the payload.
  List<InboundPayloadStructureInput> get payload;/// [payload] defines the structure of the payload.
@@ -345,11 +351,11 @@ abstract mixin class $InboundStructureInputCopyWith<$Res>  {
   factory $InboundStructureInputCopyWith(InboundStructureInput value, $Res Function(InboundStructureInput) _then) = _$InboundStructureInputCopyWithImpl;
 @useResult
 $Res call({
- bool hasPosition, InboundPositionStructureInput position, bool hasPayload, List<InboundPayloadStructureInput> payload
+ bool hasPosition, InboundPositionStructureInput? position, bool hasPayload, List<InboundPayloadStructureInput> payload
 });
 
 
-$InboundPositionStructureInputCopyWith<$Res> get position;
+$InboundPositionStructureInputCopyWith<$Res>? get position;
 
 }
 /// @nodoc
@@ -362,11 +368,11 @@ class _$InboundStructureInputCopyWithImpl<$Res>
 
 /// Create a copy of InboundStructureInput
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? hasPosition = null,Object? position = null,Object? hasPayload = null,Object? payload = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? hasPosition = null,Object? position = freezed,Object? hasPayload = null,Object? payload = null,}) {
   return _then(_self.copyWith(
 hasPosition: null == hasPosition ? _self.hasPosition : hasPosition // ignore: cast_nullable_to_non_nullable
-as bool,position: null == position ? _self.position : position // ignore: cast_nullable_to_non_nullable
-as InboundPositionStructureInput,hasPayload: null == hasPayload ? _self.hasPayload : hasPayload // ignore: cast_nullable_to_non_nullable
+as bool,position: freezed == position ? _self.position : position // ignore: cast_nullable_to_non_nullable
+as InboundPositionStructureInput?,hasPayload: null == hasPayload ? _self.hasPayload : hasPayload // ignore: cast_nullable_to_non_nullable
 as bool,payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
 as List<InboundPayloadStructureInput>,
   ));
@@ -375,9 +381,12 @@ as List<InboundPayloadStructureInput>,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$InboundPositionStructureInputCopyWith<$Res> get position {
-  
-  return $InboundPositionStructureInputCopyWith<$Res>(_self.position, (value) {
+$InboundPositionStructureInputCopyWith<$Res>? get position {
+    if (_self.position == null) {
+    return null;
+  }
+
+  return $InboundPositionStructureInputCopyWith<$Res>(_self.position!, (value) {
     return _then(_self.copyWith(position: value));
   });
 }
@@ -462,7 +471,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool hasPosition,  InboundPositionStructureInput position,  bool hasPayload,  List<InboundPayloadStructureInput> payload)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool hasPosition,  InboundPositionStructureInput? position,  bool hasPayload,  List<InboundPayloadStructureInput> payload)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _InboundStructureInput() when $default != null:
 return $default(_that.hasPosition,_that.position,_that.hasPayload,_that.payload);case _:
@@ -483,7 +492,7 @@ return $default(_that.hasPosition,_that.position,_that.hasPayload,_that.payload)
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool hasPosition,  InboundPositionStructureInput position,  bool hasPayload,  List<InboundPayloadStructureInput> payload)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool hasPosition,  InboundPositionStructureInput? position,  bool hasPayload,  List<InboundPayloadStructureInput> payload)  $default,) {final _that = this;
 switch (_that) {
 case _InboundStructureInput():
 return $default(_that.hasPosition,_that.position,_that.hasPayload,_that.payload);case _:
@@ -503,7 +512,7 @@ return $default(_that.hasPosition,_that.position,_that.hasPayload,_that.payload)
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool hasPosition,  InboundPositionStructureInput position,  bool hasPayload,  List<InboundPayloadStructureInput> payload)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool hasPosition,  InboundPositionStructureInput? position,  bool hasPayload,  List<InboundPayloadStructureInput> payload)?  $default,) {final _that = this;
 switch (_that) {
 case _InboundStructureInput() when $default != null:
 return $default(_that.hasPosition,_that.position,_that.hasPayload,_that.payload);case _:
@@ -524,7 +533,7 @@ class _InboundStructureInput implements InboundStructureInput {
 /// [hasPosition] defines if the structure has a position.
 @override@JsonKey()  bool hasPosition;
 /// [position] defines the structure of the position.
-@override  InboundPositionStructureInput position;
+@override  InboundPositionStructureInput? position;
 /// [hasPayload] defines if the structure has a payload.
 @override@JsonKey()  bool hasPayload;
 /// [payload] defines the structure of the payload.
@@ -556,11 +565,11 @@ abstract mixin class _$InboundStructureInputCopyWith<$Res> implements $InboundSt
   factory _$InboundStructureInputCopyWith(_InboundStructureInput value, $Res Function(_InboundStructureInput) _then) = __$InboundStructureInputCopyWithImpl;
 @override @useResult
 $Res call({
- bool hasPosition, InboundPositionStructureInput position, bool hasPayload, List<InboundPayloadStructureInput> payload
+ bool hasPosition, InboundPositionStructureInput? position, bool hasPayload, List<InboundPayloadStructureInput> payload
 });
 
 
-@override $InboundPositionStructureInputCopyWith<$Res> get position;
+@override $InboundPositionStructureInputCopyWith<$Res>? get position;
 
 }
 /// @nodoc
@@ -573,11 +582,11 @@ class __$InboundStructureInputCopyWithImpl<$Res>
 
 /// Create a copy of InboundStructureInput
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? hasPosition = null,Object? position = null,Object? hasPayload = null,Object? payload = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? hasPosition = null,Object? position = freezed,Object? hasPayload = null,Object? payload = null,}) {
   return _then(_InboundStructureInput(
 hasPosition: null == hasPosition ? _self.hasPosition : hasPosition // ignore: cast_nullable_to_non_nullable
-as bool,position: null == position ? _self.position : position // ignore: cast_nullable_to_non_nullable
-as InboundPositionStructureInput,hasPayload: null == hasPayload ? _self.hasPayload : hasPayload // ignore: cast_nullable_to_non_nullable
+as bool,position: freezed == position ? _self.position : position // ignore: cast_nullable_to_non_nullable
+as InboundPositionStructureInput?,hasPayload: null == hasPayload ? _self.hasPayload : hasPayload // ignore: cast_nullable_to_non_nullable
 as bool,payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
 as List<InboundPayloadStructureInput>,
   ));
@@ -587,9 +596,12 @@ as List<InboundPayloadStructureInput>,
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$InboundPositionStructureInputCopyWith<$Res> get position {
-  
-  return $InboundPositionStructureInputCopyWith<$Res>(_self.position, (value) {
+$InboundPositionStructureInputCopyWith<$Res>? get position {
+    if (_self.position == null) {
+    return null;
+  }
+
+  return $InboundPositionStructureInputCopyWith<$Res>(_self.position!, (value) {
     return _then(_self.copyWith(position: value));
   });
 }

--- a/lib/src/builder/builder.g.dart
+++ b/lib/src/builder/builder.g.dart
@@ -9,9 +9,11 @@ part of 'builder.dart';
 _InboundStructure _$InboundStructureFromJson(Map<String, dynamic> json) =>
     _InboundStructure(
       hasPosition: json['hasPosition'] as bool,
-      position: InboundPositionStructure.fromJson(
-        json['position'] as Map<String, dynamic>,
-      ),
+      position: json['position'] == null
+          ? null
+          : InboundPositionStructure.fromJson(
+              json['position'] as Map<String, dynamic>,
+            ),
       hasPayload: json['hasPayload'] as bool,
       payload: (json['payload'] as List<dynamic>)
           .map(
@@ -23,7 +25,7 @@ _InboundStructure _$InboundStructureFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$InboundStructureToJson(_InboundStructure instance) =>
     <String, dynamic>{
       'hasPosition': instance.hasPosition,
-      'position': instance.position.toJson(),
+      'position': instance.position?.toJson(),
       'hasPayload': instance.hasPayload,
       'payload': instance.payload.map((e) => e.toJson()).toList(),
     };
@@ -32,9 +34,11 @@ _InboundStructureInput _$InboundStructureInputFromJson(
   Map<String, dynamic> json,
 ) => _InboundStructureInput(
   hasPosition: json['hasPosition'] as bool? ?? true,
-  position: InboundPositionStructureInput.fromJson(
-    json['position'] as Map<String, dynamic>,
-  ),
+  position: json['position'] == null
+      ? null
+      : InboundPositionStructureInput.fromJson(
+          json['position'] as Map<String, dynamic>,
+        ),
   hasPayload: json['hasPayload'] as bool? ?? false,
   payload:
       (json['payload'] as List<dynamic>?)
@@ -51,7 +55,7 @@ Map<String, dynamic> _$InboundStructureInputToJson(
   _InboundStructureInput instance,
 ) => <String, dynamic>{
   'hasPosition': instance.hasPosition,
-  'position': instance.position.toJson(),
+  'position': instance.position?.toJson(),
   'hasPayload': instance.hasPayload,
   'payload': instance.payload.map((e) => e.toJson()).toList(),
 };

--- a/lib/src/builder/src/inbound.dart
+++ b/lib/src/builder/src/inbound.dart
@@ -4,7 +4,7 @@ part of '../builder.dart';
 abstract class InboundStructure with _$InboundStructure {
   const factory InboundStructure({
     required bool hasPosition,
-    required InboundPositionStructure position,
+    required InboundPositionStructure? position,
     required bool hasPayload,
     required List<InboundPayloadStructure> payload,
   }) = _InboundStructure;
@@ -19,7 +19,7 @@ abstract class InboundStructureInput with _$InboundStructureInput {
     @Default(true) bool hasPosition,
 
     /// [position] defines the structure of the position.
-    required InboundPositionStructureInput position,
+    required InboundPositionStructureInput? position,
 
     /// [hasPayload] defines if the structure has a payload.
     @Default(false) bool hasPayload,
@@ -90,7 +90,8 @@ enum InboundPayloadStructureType {
   string,
   integer,
   boolean,
-  float;
+  float
+  ;
 
   @override
   String toString() => toJson();

--- a/lib/src/converters/converters.dart
+++ b/lib/src/converters/converters.dart
@@ -15,3 +15,4 @@ part 'src/time_of_day.dart';
 part 'src/regex.dart';
 part 'src/byte_list.dart';
 part 'src/param_converter.dart';
+part 'src/dynamic_map.dart';

--- a/lib/src/converters/src/dynamic_map.dart
+++ b/lib/src/converters/src/dynamic_map.dart
@@ -1,0 +1,35 @@
+part of '../converters.dart';
+
+/// Safely converts any [Map] into [Map<String, dynamic>?].
+///
+/// A Dart literal `{}` inside a `Map<String, dynamic>` value slot is
+/// `Map<dynamic, dynamic>`, which fails the direct `as Map<String, dynamic>?`
+/// cast that json_serializable emits. This converter handles both variants.
+class DynamicMapConverterNullable implements JsonConverter<Map<String, dynamic>?, Object?> {
+  const DynamicMapConverterNullable();
+
+  @override
+  Map<String, dynamic>? fromJson(Object? json) {
+    if (json == null) return null;
+    if (json is Map<String, dynamic>) return json;
+    if (json is Map) return json.map((key, value) => MapEntry(key.toString(), value));
+    return null;
+  }
+
+  @override
+  Object? toJson(Map<String, dynamic>? value) => value;
+}
+
+class DynamicMapConverter implements JsonConverter<Map<String, dynamic>, Object?> {
+  const DynamicMapConverter();
+
+  @override
+  Map<String, dynamic> fromJson(Object? json) {
+    if (json is Map<String, dynamic>) return json;
+    if (json is Map) return json.map((key, value) => MapEntry(key.toString(), value));
+    return {};
+  }
+
+  @override
+  Object? toJson(Map<String, dynamic> value) => value;
+}

--- a/lib/src/inbound/inbound.freezed.dart
+++ b/lib/src/inbound/inbound.freezed.dart
@@ -1124,7 +1124,7 @@ mixin _$InboundService {
 /// IS the ID of the entity. This ID is unique.
  String get id;/// Is the Assigned service name, cannot be translated for other languages.
  String get name;/// Is the Credential object, check the documentation for more information.
- Map<String, dynamic>? get credentials;/// Is the ID of the External Account.
+@DynamicMapConverterNullable() Map<String, dynamic>? get credentials;/// Is the ID of the External Account.
  String? get externalAccountId;/// Is the update time of the service.
 @DurationOrNullConverter() Duration? get updateTime;/// Is the Protocol entity.
  InboundProtocol? get protocol;/// Is the Protocol ID.
@@ -1166,7 +1166,7 @@ abstract mixin class $InboundServiceCopyWith<$Res>  {
   factory $InboundServiceCopyWith(InboundService value, $Res Function(InboundService) _then) = _$InboundServiceCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, Map<String, dynamic>? credentials, String? externalAccountId,@DurationOrNullConverter() Duration? updateTime, InboundProtocol? protocol, String? protocolId, bool? isEnabled, String? token, InboundStructure? structure, List<Access>? access, WebhookStructure? webhookStructure
+ String id, String name,@DynamicMapConverterNullable() Map<String, dynamic>? credentials, String? externalAccountId,@DurationOrNullConverter() Duration? updateTime, InboundProtocol? protocol, String? protocolId, bool? isEnabled, String? token, InboundStructure? structure, List<Access>? access, WebhookStructure? webhookStructure
 });
 
 
@@ -1318,7 +1318,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  Map<String, dynamic>? credentials,  String? externalAccountId, @DurationOrNullConverter()  Duration? updateTime,  InboundProtocol? protocol,  String? protocolId,  bool? isEnabled,  String? token,  InboundStructure? structure,  List<Access>? access,  WebhookStructure? webhookStructure)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @DynamicMapConverterNullable()  Map<String, dynamic>? credentials,  String? externalAccountId, @DurationOrNullConverter()  Duration? updateTime,  InboundProtocol? protocol,  String? protocolId,  bool? isEnabled,  String? token,  InboundStructure? structure,  List<Access>? access,  WebhookStructure? webhookStructure)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _InboundService() when $default != null:
 return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_that.updateTime,_that.protocol,_that.protocolId,_that.isEnabled,_that.token,_that.structure,_that.access,_that.webhookStructure);case _:
@@ -1339,7 +1339,7 @@ return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_t
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  Map<String, dynamic>? credentials,  String? externalAccountId, @DurationOrNullConverter()  Duration? updateTime,  InboundProtocol? protocol,  String? protocolId,  bool? isEnabled,  String? token,  InboundStructure? structure,  List<Access>? access,  WebhookStructure? webhookStructure)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @DynamicMapConverterNullable()  Map<String, dynamic>? credentials,  String? externalAccountId, @DurationOrNullConverter()  Duration? updateTime,  InboundProtocol? protocol,  String? protocolId,  bool? isEnabled,  String? token,  InboundStructure? structure,  List<Access>? access,  WebhookStructure? webhookStructure)  $default,) {final _that = this;
 switch (_that) {
 case _InboundService():
 return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_that.updateTime,_that.protocol,_that.protocolId,_that.isEnabled,_that.token,_that.structure,_that.access,_that.webhookStructure);case _:
@@ -1359,7 +1359,7 @@ return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_t
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  Map<String, dynamic>? credentials,  String? externalAccountId, @DurationOrNullConverter()  Duration? updateTime,  InboundProtocol? protocol,  String? protocolId,  bool? isEnabled,  String? token,  InboundStructure? structure,  List<Access>? access,  WebhookStructure? webhookStructure)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @DynamicMapConverterNullable()  Map<String, dynamic>? credentials,  String? externalAccountId, @DurationOrNullConverter()  Duration? updateTime,  InboundProtocol? protocol,  String? protocolId,  bool? isEnabled,  String? token,  InboundStructure? structure,  List<Access>? access,  WebhookStructure? webhookStructure)?  $default,) {final _that = this;
 switch (_that) {
 case _InboundService() when $default != null:
 return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_that.updateTime,_that.protocol,_that.protocolId,_that.isEnabled,_that.token,_that.structure,_that.access,_that.webhookStructure);case _:
@@ -1374,7 +1374,7 @@ return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_t
 @JsonSerializable()
 
 class _InboundService implements InboundService {
-  const _InboundService({required this.id, required this.name, final  Map<String, dynamic>? credentials, this.externalAccountId, @DurationOrNullConverter() this.updateTime, this.protocol, this.protocolId, this.isEnabled, this.token, this.structure, final  List<Access>? access, this.webhookStructure}): _credentials = credentials,_access = access;
+  const _InboundService({required this.id, required this.name, @DynamicMapConverterNullable() final  Map<String, dynamic>? credentials, this.externalAccountId, @DurationOrNullConverter() this.updateTime, this.protocol, this.protocolId, this.isEnabled, this.token, this.structure, final  List<Access>? access, this.webhookStructure}): _credentials = credentials,_access = access;
   factory _InboundService.fromJson(Map<String, dynamic> json) => _$InboundServiceFromJson(json);
 
 /// IS the ID of the entity. This ID is unique.
@@ -1384,7 +1384,7 @@ class _InboundService implements InboundService {
 /// Is the Credential object, check the documentation for more information.
  final  Map<String, dynamic>? _credentials;
 /// Is the Credential object, check the documentation for more information.
-@override Map<String, dynamic>? get credentials {
+@override@DynamicMapConverterNullable() Map<String, dynamic>? get credentials {
   final value = _credentials;
   if (value == null) return null;
   if (_credentials is EqualUnmodifiableMapView) return _credentials;
@@ -1453,7 +1453,7 @@ abstract mixin class _$InboundServiceCopyWith<$Res> implements $InboundServiceCo
   factory _$InboundServiceCopyWith(_InboundService value, $Res Function(_InboundService) _then) = __$InboundServiceCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, Map<String, dynamic>? credentials, String? externalAccountId,@DurationOrNullConverter() Duration? updateTime, InboundProtocol? protocol, String? protocolId, bool? isEnabled, String? token, InboundStructure? structure, List<Access>? access, WebhookStructure? webhookStructure
+ String id, String name,@DynamicMapConverterNullable() Map<String, dynamic>? credentials, String? externalAccountId,@DurationOrNullConverter() Duration? updateTime, InboundProtocol? protocol, String? protocolId, bool? isEnabled, String? token, InboundStructure? structure, List<Access>? access, WebhookStructure? webhookStructure
 });
 
 
@@ -1536,8 +1536,8 @@ mixin _$InboundServiceInput {
  set id(String? value);/// [name] is the Assigned service name, cannot be translated for other languages.
  String get name;/// [name] is the Assigned service name, cannot be translated for other languages.
  set name(String value);/// [credentials] is the Credential object, check the documentation for more information.
- Map<String, dynamic> get credentials;/// [credentials] is the Credential object, check the documentation for more information.
- set credentials(Map<String, dynamic> value);/// [externalAccountId] is the ID of the External Account.
+@DynamicMapConverter() Map<String, dynamic> get credentials;/// [credentials] is the Credential object, check the documentation for more information.
+@DynamicMapConverter() set credentials(Map<String, dynamic> value);/// [externalAccountId] is the ID of the External Account.
  String? get externalAccountId;/// [externalAccountId] is the ID of the External Account.
  set externalAccountId(String? value);/// [protocolId] is the ID of the Protocol.
  String? get protocolId;/// [protocolId] is the ID of the Protocol.
@@ -1569,7 +1569,7 @@ abstract mixin class $InboundServiceInputCopyWith<$Res>  {
   factory $InboundServiceInputCopyWith(InboundServiceInput value, $Res Function(InboundServiceInput) _then) = _$InboundServiceInputCopyWithImpl;
 @useResult
 $Res call({
- String? id, String name, Map<String, dynamic> credentials, String? externalAccountId, String? protocolId, InboundStructureInput structure
+ String? id, String name,@DynamicMapConverter() Map<String, dynamic> credentials, String? externalAccountId, String? protocolId, InboundStructureInput structure
 });
 
 
@@ -1688,7 +1688,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  String name,  Map<String, dynamic> credentials,  String? externalAccountId,  String? protocolId,  InboundStructureInput structure)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  String name, @DynamicMapConverter()  Map<String, dynamic> credentials,  String? externalAccountId,  String? protocolId,  InboundStructureInput structure)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _InboundServiceInput() when $default != null:
 return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_that.protocolId,_that.structure);case _:
@@ -1709,7 +1709,7 @@ return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_t
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  String name,  Map<String, dynamic> credentials,  String? externalAccountId,  String? protocolId,  InboundStructureInput structure)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  String name, @DynamicMapConverter()  Map<String, dynamic> credentials,  String? externalAccountId,  String? protocolId,  InboundStructureInput structure)  $default,) {final _that = this;
 switch (_that) {
 case _InboundServiceInput():
 return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_that.protocolId,_that.structure);case _:
@@ -1729,7 +1729,7 @@ return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_t
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  String name,  Map<String, dynamic> credentials,  String? externalAccountId,  String? protocolId,  InboundStructureInput structure)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  String name, @DynamicMapConverter()  Map<String, dynamic> credentials,  String? externalAccountId,  String? protocolId,  InboundStructureInput structure)?  $default,) {final _that = this;
 switch (_that) {
 case _InboundServiceInput() when $default != null:
 return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_that.protocolId,_that.structure);case _:
@@ -1744,7 +1744,7 @@ return $default(_that.id,_that.name,_that.credentials,_that.externalAccountId,_t
 @JsonSerializable()
 
 class _InboundServiceInput implements InboundServiceInput {
-   _InboundServiceInput({this.id, this.name = '', this.credentials = const {}, this.externalAccountId, this.protocolId, required this.structure});
+   _InboundServiceInput({this.id, this.name = '', @DynamicMapConverter() this.credentials = const <String, dynamic>{}, this.externalAccountId, this.protocolId, required this.structure});
   factory _InboundServiceInput.fromJson(Map<String, dynamic> json) => _$InboundServiceInputFromJson(json);
 
 /// [id] is the ID of the entity. This ID is unique. Should be null when creating a new entity.
@@ -1752,7 +1752,7 @@ class _InboundServiceInput implements InboundServiceInput {
 /// [name] is the Assigned service name, cannot be translated for other languages.
 @override@JsonKey()  String name;
 /// [credentials] is the Credential object, check the documentation for more information.
-@override@JsonKey()  Map<String, dynamic> credentials;
+@override@JsonKey()@DynamicMapConverter()  Map<String, dynamic> credentials;
 /// [externalAccountId] is the ID of the External Account.
 @override  String? externalAccountId;
 /// [protocolId] is the ID of the Protocol.
@@ -1786,7 +1786,7 @@ abstract mixin class _$InboundServiceInputCopyWith<$Res> implements $InboundServ
   factory _$InboundServiceInputCopyWith(_InboundServiceInput value, $Res Function(_InboundServiceInput) _then) = __$InboundServiceInputCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, String name, Map<String, dynamic> credentials, String? externalAccountId, String? protocolId, InboundStructureInput structure
+ String? id, String name,@DynamicMapConverter() Map<String, dynamic> credentials, String? externalAccountId, String? protocolId, InboundStructureInput structure
 });
 
 

--- a/lib/src/inbound/inbound.g.dart
+++ b/lib/src/inbound/inbound.g.dart
@@ -260,7 +260,9 @@ _InboundService _$InboundServiceFromJson(Map<String, dynamic> json) =>
     _InboundService(
       id: json['id'] as String,
       name: json['name'] as String,
-      credentials: json['credentials'] as Map<String, dynamic>?,
+      credentials: const DynamicMapConverterNullable().fromJson(
+        json['credentials'],
+      ),
       externalAccountId: json['externalAccountId'] as String?,
       updateTime: const DurationOrNullConverter().fromJson(
         json['updateTime'] as num?,
@@ -290,7 +292,9 @@ Map<String, dynamic> _$InboundServiceToJson(_InboundService instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
-      'credentials': instance.credentials,
+      'credentials': const DynamicMapConverterNullable().toJson(
+        instance.credentials,
+      ),
       'externalAccountId': instance.externalAccountId,
       'updateTime': const DurationOrNullConverter().toJson(instance.updateTime),
       'protocol': instance.protocol?.toJson(),
@@ -306,7 +310,9 @@ _InboundServiceInput _$InboundServiceInputFromJson(Map<String, dynamic> json) =>
     _InboundServiceInput(
       id: json['id'] as String?,
       name: json['name'] as String? ?? '',
-      credentials: json['credentials'] as Map<String, dynamic>? ?? const {},
+      credentials: json['credentials'] == null
+          ? const <String, dynamic>{}
+          : const DynamicMapConverter().fromJson(json['credentials']),
       externalAccountId: json['externalAccountId'] as String?,
       protocolId: json['protocolId'] as String?,
       structure: InboundStructureInput.fromJson(
@@ -319,7 +325,7 @@ Map<String, dynamic> _$InboundServiceInputToJson(
 ) => <String, dynamic>{
   'id': instance.id,
   'name': instance.name,
-  'credentials': instance.credentials,
+  'credentials': const DynamicMapConverter().toJson(instance.credentials),
   'externalAccountId': instance.externalAccountId,
   'protocolId': instance.protocolId,
   'structure': instance.structure.toJson(),

--- a/lib/src/inbound/src/service.dart
+++ b/lib/src/inbound/src/service.dart
@@ -10,7 +10,7 @@ abstract class InboundService with _$InboundService {
     required String name,
 
     /// Is the Credential object, check the documentation for more information.
-    Map<String, dynamic>? credentials,
+    @DynamicMapConverterNullable() Map<String, dynamic>? credentials,
 
     /// Is the ID of the External Account.
     String? externalAccountId,
@@ -54,7 +54,7 @@ abstract class InboundServiceInput with _$InboundServiceInput {
     @Default('') String name,
 
     /// [credentials] is the Credential object, check the documentation for more information.
-    @Default({}) Map<String, dynamic> credentials,
+    @Default(<String, dynamic>{}) @DynamicMapConverter() Map<String, dynamic> credentials,
 
     /// [externalAccountId] is the ID of the External Account.
     String? externalAccountId,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.8.11"
+version: "3.8.12"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:
@@ -28,7 +28,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
   build_runner: ^2.10.4
-  freezed: ^3.2.3
+  freezed: ^3.2.5
   json_serializable: ^6.11.0
   test: ^1.26.2
 

--- a/test/inbound_service_test.dart
+++ b/test/inbound_service_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:layrz_models/layrz_models.dart';
+
+void main() {
+  test('inbound service test', () {
+    final Map<String, dynamic> data = {
+      "id": "318",
+      "name": "testcrear2222233",
+      "credentials": {},
+      "protocolId": "18",
+      "externalAccountId": null,
+      "structure": {"hasPosition": false, "position": null, "hasPayload": false, "payload": []},
+      "isEnabled": true,
+      "token": null,
+      "access": [],
+      "webhookStructure": null,
+    };
+
+    final inboundService = InboundService.fromJson(data);
+    expect(inboundService.id, "318");
+    expect(inboundService.name, "testcrear2222233");
+  });
+
+  test('inbound service input test', () {
+    final inboundServiceInput = {
+      "id": "315",
+      "name": "TESTOMNI",
+      "credentials": {},
+      "protocolId": "18",
+      "externalAccountId": null,
+      "structure": {"hasPosition": false, "position": null, "hasPayload": false, "payload": []},
+      "isEnabled": true,
+      "token": null,
+      "access": [],
+      "webhookStructure": null,
+      "protocol": {
+        "id": "18",
+        "name": "omnilink",
+        "color": "blue darken-2",
+        "isEnabled": true,
+        "operationMode": "ASYNC",
+        "isImported": true,
+        "webhookStructure": null,
+      },
+    };
+    final result = InboundService.fromJson(inboundServiceInput);
+
+    expect(result.name, "TESTOMNI");
+    final resultInput = InboundServiceInput.fromJson(inboundServiceInput);
+    expect(resultInput.name, "TESTOMNI");
+  });
+}


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to the handling of inbound structures, particularly making the `position` field nullable to support services without a position structure. It also adds new converters for safer deserialization of dynamic maps and updates Flutter and DevTools configuration files. Below are the most important changes:

### Inbound Structure Nullability and CopyWith Improvements

* Made the `position` field nullable (`InboundPositionStructure?` and `InboundPositionStructureInput?`) in `InboundStructure` and `InboundStructureInput`, including all relevant methods, constructors, and copyWith implementations, to support services that do not require a position structure. [[1]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L18-R18) [[2]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L51-R55) [[3]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L68-R72) [[4]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L81-R86) [[5]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L168-R171) [[6]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L189-R192) [[7]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L209-R212) [[8]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L228-R231) [[9]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L271-R278) [[10]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L288-R295) [[11]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L302-R310) [[12]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L317-R324) [[13]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L348-R358) [[14]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L365-R375) [[15]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L378-R389) [[16]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L465-R474) [[17]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L486-R495) [[18]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L506-R515) [[19]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L527-R536) [[20]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L559-R572) [[21]](diffhunk://#diff-ec70a4d6baefa4df31b545ba17bc263aa53be9f0fee40181f5d2ff42bd875892L576-R589)

### Deserialization and Converter Enhancements

* Added `DynamicMapConverter` and `DynamicMapConverterNullable` for safe deserialization of `Map<dynamic, dynamic>` to `Map<String, dynamic>`, and applied these to `InboundService.credentials` and `InboundServiceInput.credentials` to prevent failures when credentials are provided as empty map literals.

### Flutter and Tooling Configuration

* Updated the Flutter version in `.fvmrc` from `3.41.8` to `3.41.9`.
* Added configuration to `devtools_options.yaml` to disable `drift` and `shared_preferences` extensions by default.

### Documentation

* Updated `CHANGELOG.md` to document the above changes as part of version `3.8.12`.