### PR TITLE
Set default destinyInformation to empty list in AtsLoadingParamsFormInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.13
+
+- Changed `destinyInformation` field in `AtsLoadingParamsFormInput` from nullable `List<AtsDestinyInformationInput>?` to non-nullable `List<AtsDestinyInformationInput>` with `@Default([])` to ensure it always defaults to an empty list.
+
 ## 3.8.12
 
 - Made `position` field nullable (`InboundPositionStructure?`) in `InboundStructure` and `InboundStructureInput` to support services without a position structure.

--- a/lib/src/ats/ats.freezed.dart
+++ b/lib/src/ats/ats.freezed.dart
@@ -7820,8 +7820,8 @@ mixin _$AtsLoadingParamsFormInput {
  set correctionFactor(double? value);/// `liquidWeight` Liquid weight for third-party storage
  double? get liquidWeight;/// `liquidWeight` Liquid weight for third-party storage
  set liquidWeight(double? value);/// `destinyInformation` Destiny information only on modality seta
- List<AtsDestinyInformationInput>? get destinyInformation;/// `destinyInformation` Destiny information only on modality seta
- set destinyInformation(List<AtsDestinyInformationInput>? value);
+ List<AtsDestinyInformationInput> get destinyInformation;/// `destinyInformation` Destiny information only on modality seta
+ set destinyInformation(List<AtsDestinyInformationInput> value);
 /// Create a copy of AtsLoadingParamsFormInput
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -7847,7 +7847,7 @@ abstract mixin class $AtsLoadingParamsFormInputCopyWith<$Res>  {
   factory $AtsLoadingParamsFormInputCopyWith(AtsLoadingParamsFormInput value, $Res Function(AtsLoadingParamsFormInput) _then) = _$AtsLoadingParamsFormInputCopyWithImpl;
 @useResult
 $Res call({
- String? id, String? formNumber, String? assetId, String? receptionId, String? driver, double? sampleDensity, double? sampleTemperature, double? assetTemperature, double? analyzedAt,@AtsLoadingParamsSampleOrNullConverter() AtsLoadingParamsSample? sampleType, String? fuelSubtype, double? ambientVolume,@AtsParamsFormModalityOrNullConverter() ParamsFormModality? modality, double? inpm, double? initialWeight, double? finalWeight, double? volume20, double? density20, double? correctionFactor, double? liquidWeight, List<AtsDestinyInformationInput>? destinyInformation
+ String? id, String? formNumber, String? assetId, String? receptionId, String? driver, double? sampleDensity, double? sampleTemperature, double? assetTemperature, double? analyzedAt,@AtsLoadingParamsSampleOrNullConverter() AtsLoadingParamsSample? sampleType, String? fuelSubtype, double? ambientVolume,@AtsParamsFormModalityOrNullConverter() ParamsFormModality? modality, double? inpm, double? initialWeight, double? finalWeight, double? volume20, double? density20, double? correctionFactor, double? liquidWeight, List<AtsDestinyInformationInput> destinyInformation
 });
 
 
@@ -7864,7 +7864,7 @@ class _$AtsLoadingParamsFormInputCopyWithImpl<$Res>
 
 /// Create a copy of AtsLoadingParamsFormInput
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? formNumber = freezed,Object? assetId = freezed,Object? receptionId = freezed,Object? driver = freezed,Object? sampleDensity = freezed,Object? sampleTemperature = freezed,Object? assetTemperature = freezed,Object? analyzedAt = freezed,Object? sampleType = freezed,Object? fuelSubtype = freezed,Object? ambientVolume = freezed,Object? modality = freezed,Object? inpm = freezed,Object? initialWeight = freezed,Object? finalWeight = freezed,Object? volume20 = freezed,Object? density20 = freezed,Object? correctionFactor = freezed,Object? liquidWeight = freezed,Object? destinyInformation = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? formNumber = freezed,Object? assetId = freezed,Object? receptionId = freezed,Object? driver = freezed,Object? sampleDensity = freezed,Object? sampleTemperature = freezed,Object? assetTemperature = freezed,Object? analyzedAt = freezed,Object? sampleType = freezed,Object? fuelSubtype = freezed,Object? ambientVolume = freezed,Object? modality = freezed,Object? inpm = freezed,Object? initialWeight = freezed,Object? finalWeight = freezed,Object? volume20 = freezed,Object? density20 = freezed,Object? correctionFactor = freezed,Object? liquidWeight = freezed,Object? destinyInformation = null,}) {
   return _then(_self.copyWith(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,formNumber: freezed == formNumber ? _self.formNumber : formNumber // ignore: cast_nullable_to_non_nullable
@@ -7886,8 +7886,8 @@ as double?,volume20: freezed == volume20 ? _self.volume20 : volume20 // ignore: 
 as double?,density20: freezed == density20 ? _self.density20 : density20 // ignore: cast_nullable_to_non_nullable
 as double?,correctionFactor: freezed == correctionFactor ? _self.correctionFactor : correctionFactor // ignore: cast_nullable_to_non_nullable
 as double?,liquidWeight: freezed == liquidWeight ? _self.liquidWeight : liquidWeight // ignore: cast_nullable_to_non_nullable
-as double?,destinyInformation: freezed == destinyInformation ? _self.destinyInformation : destinyInformation // ignore: cast_nullable_to_non_nullable
-as List<AtsDestinyInformationInput>?,
+as double?,destinyInformation: null == destinyInformation ? _self.destinyInformation : destinyInformation // ignore: cast_nullable_to_non_nullable
+as List<AtsDestinyInformationInput>,
   ));
 }
 
@@ -7972,7 +7972,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  double? correctionFactor,  double? liquidWeight,  List<AtsDestinyInformationInput>? destinyInformation)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  double? correctionFactor,  double? liquidWeight,  List<AtsDestinyInformationInput> destinyInformation)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AtsLoadingParamsFormInput() when $default != null:
 return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.driver,_that.sampleDensity,_that.sampleTemperature,_that.assetTemperature,_that.analyzedAt,_that.sampleType,_that.fuelSubtype,_that.ambientVolume,_that.modality,_that.inpm,_that.initialWeight,_that.finalWeight,_that.volume20,_that.density20,_that.correctionFactor,_that.liquidWeight,_that.destinyInformation);case _:
@@ -7993,7 +7993,7 @@ return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  double? correctionFactor,  double? liquidWeight,  List<AtsDestinyInformationInput>? destinyInformation)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  double? correctionFactor,  double? liquidWeight,  List<AtsDestinyInformationInput> destinyInformation)  $default,) {final _that = this;
 switch (_that) {
 case _AtsLoadingParamsFormInput():
 return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.driver,_that.sampleDensity,_that.sampleTemperature,_that.assetTemperature,_that.analyzedAt,_that.sampleType,_that.fuelSubtype,_that.ambientVolume,_that.modality,_that.inpm,_that.initialWeight,_that.finalWeight,_that.volume20,_that.density20,_that.correctionFactor,_that.liquidWeight,_that.destinyInformation);case _:
@@ -8013,7 +8013,7 @@ return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  double? correctionFactor,  double? liquidWeight,  List<AtsDestinyInformationInput>? destinyInformation)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  String? formNumber,  String? assetId,  String? receptionId,  String? driver,  double? sampleDensity,  double? sampleTemperature,  double? assetTemperature,  double? analyzedAt, @AtsLoadingParamsSampleOrNullConverter()  AtsLoadingParamsSample? sampleType,  String? fuelSubtype,  double? ambientVolume, @AtsParamsFormModalityOrNullConverter()  ParamsFormModality? modality,  double? inpm,  double? initialWeight,  double? finalWeight,  double? volume20,  double? density20,  double? correctionFactor,  double? liquidWeight,  List<AtsDestinyInformationInput> destinyInformation)?  $default,) {final _that = this;
 switch (_that) {
 case _AtsLoadingParamsFormInput() when $default != null:
 return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.driver,_that.sampleDensity,_that.sampleTemperature,_that.assetTemperature,_that.analyzedAt,_that.sampleType,_that.fuelSubtype,_that.ambientVolume,_that.modality,_that.inpm,_that.initialWeight,_that.finalWeight,_that.volume20,_that.density20,_that.correctionFactor,_that.liquidWeight,_that.destinyInformation);case _:
@@ -8028,7 +8028,7 @@ return $default(_that.id,_that.formNumber,_that.assetId,_that.receptionId,_that.
 @JsonSerializable()
 
 class _AtsLoadingParamsFormInput implements AtsLoadingParamsFormInput {
-   _AtsLoadingParamsFormInput({this.id, this.formNumber, this.assetId, this.receptionId, this.driver, this.sampleDensity, this.sampleTemperature, this.assetTemperature, this.analyzedAt, @AtsLoadingParamsSampleOrNullConverter() this.sampleType, this.fuelSubtype, this.ambientVolume, @AtsParamsFormModalityOrNullConverter() this.modality, this.inpm, this.initialWeight, this.finalWeight, this.volume20, this.density20, this.correctionFactor, this.liquidWeight, this.destinyInformation});
+   _AtsLoadingParamsFormInput({this.id, this.formNumber, this.assetId, this.receptionId, this.driver, this.sampleDensity, this.sampleTemperature, this.assetTemperature, this.analyzedAt, @AtsLoadingParamsSampleOrNullConverter() this.sampleType, this.fuelSubtype, this.ambientVolume, @AtsParamsFormModalityOrNullConverter() this.modality, this.inpm, this.initialWeight, this.finalWeight, this.volume20, this.density20, this.correctionFactor, this.liquidWeight, this.destinyInformation = const []});
   factory _AtsLoadingParamsFormInput.fromJson(Map<String, dynamic> json) => _$AtsLoadingParamsFormInputFromJson(json);
 
 /// `id` of the loading params form, ignore it if you are using "addLoadingParams" mutation
@@ -8072,7 +8072,7 @@ class _AtsLoadingParamsFormInput implements AtsLoadingParamsFormInput {
 /// `liquidWeight` Liquid weight for third-party storage
 @override  double? liquidWeight;
 /// `destinyInformation` Destiny information only on modality seta
-@override  List<AtsDestinyInformationInput>? destinyInformation;
+@override@JsonKey()  List<AtsDestinyInformationInput> destinyInformation;
 
 /// Create a copy of AtsLoadingParamsFormInput
 /// with the given fields replaced by the non-null parameter values.
@@ -8100,7 +8100,7 @@ abstract mixin class _$AtsLoadingParamsFormInputCopyWith<$Res> implements $AtsLo
   factory _$AtsLoadingParamsFormInputCopyWith(_AtsLoadingParamsFormInput value, $Res Function(_AtsLoadingParamsFormInput) _then) = __$AtsLoadingParamsFormInputCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, String? formNumber, String? assetId, String? receptionId, String? driver, double? sampleDensity, double? sampleTemperature, double? assetTemperature, double? analyzedAt,@AtsLoadingParamsSampleOrNullConverter() AtsLoadingParamsSample? sampleType, String? fuelSubtype, double? ambientVolume,@AtsParamsFormModalityOrNullConverter() ParamsFormModality? modality, double? inpm, double? initialWeight, double? finalWeight, double? volume20, double? density20, double? correctionFactor, double? liquidWeight, List<AtsDestinyInformationInput>? destinyInformation
+ String? id, String? formNumber, String? assetId, String? receptionId, String? driver, double? sampleDensity, double? sampleTemperature, double? assetTemperature, double? analyzedAt,@AtsLoadingParamsSampleOrNullConverter() AtsLoadingParamsSample? sampleType, String? fuelSubtype, double? ambientVolume,@AtsParamsFormModalityOrNullConverter() ParamsFormModality? modality, double? inpm, double? initialWeight, double? finalWeight, double? volume20, double? density20, double? correctionFactor, double? liquidWeight, List<AtsDestinyInformationInput> destinyInformation
 });
 
 
@@ -8117,7 +8117,7 @@ class __$AtsLoadingParamsFormInputCopyWithImpl<$Res>
 
 /// Create a copy of AtsLoadingParamsFormInput
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? formNumber = freezed,Object? assetId = freezed,Object? receptionId = freezed,Object? driver = freezed,Object? sampleDensity = freezed,Object? sampleTemperature = freezed,Object? assetTemperature = freezed,Object? analyzedAt = freezed,Object? sampleType = freezed,Object? fuelSubtype = freezed,Object? ambientVolume = freezed,Object? modality = freezed,Object? inpm = freezed,Object? initialWeight = freezed,Object? finalWeight = freezed,Object? volume20 = freezed,Object? density20 = freezed,Object? correctionFactor = freezed,Object? liquidWeight = freezed,Object? destinyInformation = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? formNumber = freezed,Object? assetId = freezed,Object? receptionId = freezed,Object? driver = freezed,Object? sampleDensity = freezed,Object? sampleTemperature = freezed,Object? assetTemperature = freezed,Object? analyzedAt = freezed,Object? sampleType = freezed,Object? fuelSubtype = freezed,Object? ambientVolume = freezed,Object? modality = freezed,Object? inpm = freezed,Object? initialWeight = freezed,Object? finalWeight = freezed,Object? volume20 = freezed,Object? density20 = freezed,Object? correctionFactor = freezed,Object? liquidWeight = freezed,Object? destinyInformation = null,}) {
   return _then(_AtsLoadingParamsFormInput(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,formNumber: freezed == formNumber ? _self.formNumber : formNumber // ignore: cast_nullable_to_non_nullable
@@ -8139,8 +8139,8 @@ as double?,volume20: freezed == volume20 ? _self.volume20 : volume20 // ignore: 
 as double?,density20: freezed == density20 ? _self.density20 : density20 // ignore: cast_nullable_to_non_nullable
 as double?,correctionFactor: freezed == correctionFactor ? _self.correctionFactor : correctionFactor // ignore: cast_nullable_to_non_nullable
 as double?,liquidWeight: freezed == liquidWeight ? _self.liquidWeight : liquidWeight // ignore: cast_nullable_to_non_nullable
-as double?,destinyInformation: freezed == destinyInformation ? _self.destinyInformation : destinyInformation // ignore: cast_nullable_to_non_nullable
-as List<AtsDestinyInformationInput>?,
+as double?,destinyInformation: null == destinyInformation ? _self.destinyInformation : destinyInformation // ignore: cast_nullable_to_non_nullable
+as List<AtsDestinyInformationInput>,
   ));
 }
 

--- a/lib/src/ats/ats.g.dart
+++ b/lib/src/ats/ats.g.dart
@@ -864,11 +864,14 @@ _AtsLoadingParamsFormInput _$AtsLoadingParamsFormInputFromJson(
   density20: (json['density20'] as num?)?.toDouble(),
   correctionFactor: (json['correctionFactor'] as num?)?.toDouble(),
   liquidWeight: (json['liquidWeight'] as num?)?.toDouble(),
-  destinyInformation: (json['destinyInformation'] as List<dynamic>?)
-      ?.map(
-        (e) => AtsDestinyInformationInput.fromJson(e as Map<String, dynamic>),
-      )
-      .toList(),
+  destinyInformation:
+      (json['destinyInformation'] as List<dynamic>?)
+          ?.map(
+            (e) =>
+                AtsDestinyInformationInput.fromJson(e as Map<String, dynamic>),
+          )
+          .toList() ??
+      const [],
 );
 
 Map<String, dynamic> _$AtsLoadingParamsFormInputToJson(
@@ -899,7 +902,7 @@ Map<String, dynamic> _$AtsLoadingParamsFormInputToJson(
   'correctionFactor': instance.correctionFactor,
   'liquidWeight': instance.liquidWeight,
   'destinyInformation': instance.destinyInformation
-      ?.map((e) => e.toJson())
+      .map((e) => e.toJson())
       .toList(),
 };
 

--- a/lib/src/ats/src/reception/loading_params_form_input.dart
+++ b/lib/src/ats/src/reception/loading_params_form_input.dart
@@ -64,7 +64,7 @@ abstract class AtsLoadingParamsFormInput with _$AtsLoadingParamsFormInput {
     double? liquidWeight,
 
     /// `destinyInformation` Destiny information only on modality seta
-    List<AtsDestinyInformationInput>? destinyInformation,
+    @Default([]) List<AtsDestinyInformationInput> destinyInformation,
   }) = _AtsLoadingParamsFormInput;
 
   factory AtsLoadingParamsFormInput.fromJson(Map<String, dynamic> json) => _$AtsLoadingParamsFormInputFromJson(json);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.8.12"
+version: "3.8.13"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
This pull request updates the `AtsLoadingParamsFormInput` model to make the `destinyInformation` field non-nullable and ensures it always defaults to an empty list. This change affects the model definition, code generation, and JSON serialization/deserialization to improve type safety and avoid potential null-related bugs.

**Model and API changes:**

- Changed the `destinyInformation` field in `AtsLoadingParamsFormInput` from a nullable `List<AtsDestinyInformationInput>?` to a non-nullable `List<AtsDestinyInformationInput>` with a default value of an empty list using `@Default([])`. This ensures the field is always present and never null. [[1]](diffhunk://#diff-fe0f0a88fbd9a3a4b809e11fe417bc56a7b32f1475a603e0b8d750314226279bL67-R67) [[2]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL7823-R7824)

**Code generation and copyWith methods:**

- Updated the generated `copyWith` methods and constructors in `lib/src/ats/ats.freezed.dart` to reflect the new non-nullable type and default value for `destinyInformation`. This includes changing method signatures and default parameter values. [[1]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL7850-R7850) [[2]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL7867-R7867) [[3]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL7889-R7890) [[4]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL7975-R7975) [[5]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL7996-R7996) [[6]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL8016-R8016) [[7]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL8031-R8031) [[8]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL8075-R8075) [[9]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL8103-R8103) [[10]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL8120-R8120) [[11]](diffhunk://#diff-af80d177978d5c102fedeb9ccff7c9c1b5f3595dce62b8fd3ab4f4c0f4ff9a2bL8142-R8143)

**Serialization/Deserialization:**

- Modified the generated JSON serialization and deserialization logic to ensure `destinyInformation` is always deserialized as a non-null list (defaulting to `[]` if missing or null in the JSON). [[1]](diffhunk://#diff-d5b0f7a70aed3bddcf31af9684db88e0fc0a706793a67acc9765d7a0a16dc664L867-R874) [[2]](diffhunk://#diff-d5b0f7a70aed3bddcf31af9684db88e0fc0a706793a67acc9765d7a0a16dc664L902-R905)

**Documentation and versioning:**

- Updated the `CHANGELOG.md` to document this change and bumped the package version to `3.8.13` in `pubspec.yaml`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4)