### PR TITLE
fix(models): align RenderWidget.magnet with backend MAGNET enum value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.16
+
+- Fixed `RenderWidget.magnet` enum value: corrected `@JsonValue` from `'MAGNET_SENSOR'` to `'MAGNET'` to match the backend `Widget` enum.
+
 ## 3.8.15
 
 - Added `originalBuyerAsset` field (`Asset?`) to `AtsPurchaseOrder` to expose the original buyer asset linked to the purchase order.

--- a/lib/src/models/models.g.dart
+++ b/lib/src/models/models.g.dart
@@ -84,7 +84,7 @@ const _$ConfIoTLayoutEnumMap = {
 const _$RenderWidgetEnumMap = {
   RenderWidget.thermometer: 'THERMOMETER',
   RenderWidget.humidity: 'HUMIDITY',
-  RenderWidget.magnetSensor: 'MAGNET_SENSOR',
+  RenderWidget.magnet: 'MAGNET',
   RenderWidget.magnetCount: 'MAGNET_COUNT',
   RenderWidget.accelerometer: 'ACCELERATION',
   RenderWidget.pressure: 'PRESSURE',

--- a/lib/src/models/src/widget.dart
+++ b/lib/src/models/src/widget.dart
@@ -11,8 +11,8 @@ enum RenderWidget {
   humidity,
 
   /// Magnet sensor state display
-  @JsonValue('MAGNET_SENSOR')
-  magnetSensor,
+  @JsonValue('MAGNET')
+  magnet,
 
   /// Magnet sensor count display
   @JsonValue('MAGNET_COUNT')

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.8.15"
+version: "3.8.16"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
## 📋 Summary

- `RenderWidget` had a stale `MAGNET_SENSOR` JSON value that never matched the backend — magnet widgets would silently fall back to `unknown` at runtime.
- Corrected the variant name (`magnetSensor` → `magnet`) and its `@JsonValue` (`'MAGNET_SENSOR'` → `'MAGNET'`) to match the backend `Widget` enum exactly.
- Bumped version to `3.8.16` and updated `CHANGELOG.md`.

## 🐛 Fixes

- `RenderWidget.magnet`: changed `@JsonValue` from `'MAGNET_SENSOR'` to `'MAGNET'` to match the backend `Widget` enum and prevent silent fallback to `unknown`.

## 🔧 Chore / Config

- Bumped `pubspec.yaml` version from `3.8.15` to `3.8.16`.
- Updated `CHANGELOG.md` with the `3.8.16` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)