### PR TITLE
Add atsShowOnlyLastExit to ReferenceCategory enum and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.8.17
+
+- Added `ReferenceCategory.atsShowOnlyLastExit` (`ATS_SHOW_ONLY_LAST_EXIT`) to flag pump assets whose exit history should be limited to the most recent record.
+
 ## 3.8.16
 
 - Fixed `RenderWidget.magnet` enum value: corrected `@JsonValue` from `'MAGNET_SENSOR'` to `'MAGNET'` to match the backend `Widget` enum.

--- a/lib/src/references/references.g.dart
+++ b/lib/src/references/references.g.dart
@@ -90,6 +90,7 @@ const _$ReferenceCategoryEnumMap = {
   ReferenceCategory.atsGetAllTerminals: 'ATS_GET_ALL_TERMINALS',
   ReferenceCategory.atsStorageReceptionAccess: 'ATS_STORAGE_RECEPTION_ACCESS',
   ReferenceCategory.atsInvoiceSwap: 'ATS_INVOICE_SWAP',
+  ReferenceCategory.atsShowOnlyLastExit: 'ATS_SHOW_ONLY_LAST_EXIT',
   ReferenceCategory.mappitOperator: 'MAPPIT_OPERATOR',
   ReferenceCategory.mappitCustomer: 'MAPPIT_CUSTOMER',
   ReferenceCategory.mappitEmployee: 'MAPPIT_EMPLOYEE',

--- a/lib/src/references/src/category.dart
+++ b/lib/src/references/src/category.dart
@@ -288,6 +288,13 @@ enum ReferenceCategory {
   @JsonValue('ATS_INVOICE_SWAP')
   atsInvoiceSwap,
 
+  /// !ATS Reference
+  /// [AllTank Systems] When present on a pump asset, the history view must
+  /// show only the most recent exit instead of the full list.
+  /// Layrz API Reference: ATS_SHOW_ONLY_LAST_EXIT
+  @JsonValue('ATS_SHOW_ONLY_LAST_EXIT')
+  atsShowOnlyLastExit,
+
   /// !Mappit Reference
   /// Defines the access to the Mappit module as a operator or mappit employee
   /// Layrz API Reference: MAPPIT_OPERATOR

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.8.16"
+version: "3.8.17"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
This pull request introduces a new reference category to the Layrz API models, specifically for pump assets that should only display the most recent exit in their history. The update includes documentation, enum changes, and serialization support for this new category.

New Reference Category for Pump Asset Exit History:

* Added `ReferenceCategory.atsShowOnlyLastExit` to the `ReferenceCategory` enum, with documentation explaining its use for limiting pump asset exit history to the most recent record. (`lib/src/references/src/category.dart`)
* Updated the enum-to-JSON mapping to include the new `ATS_SHOW_ONLY_LAST_EXIT` value for correct serialization and deserialization. (`lib/src/references/references.g.dart`)

Versioning and Documentation:

* Bumped the package version to `3.8.17` and updated the `CHANGELOG.md` to document the new reference category. (`pubspec.yaml`, `CHANGELOG.md`) [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6)