### PR TITLE
feat(ats): add purchaseOrderIds to AtsReceptionInput and bump to 3.8.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.8.18
+
+- Added `purchaseOrderIds` field (`List<String>?`) to `AtsReceptionInput` to align with the GraphQL `ReceptionInput` schema.
+- Deprecated `ordersIds` field in `AtsReceptionInput` in favor of `purchaseOrderIds`.
+
 ## 3.8.17
 
 - Added `ReferenceCategory.atsShowOnlyLastExit` (`ATS_SHOW_ONLY_LAST_EXIT`) to flag pump assets whose exit history should be limited to the most recent record.

--- a/lib/src/ats/ats.freezed.dart
+++ b/lib/src/ats/ats.freezed.dart
@@ -603,8 +603,8 @@ mixin _$AtsReceptionInput {
 ///ID of the [AtsReception]. This ID is unique.
  String? get id;///ID of the [AtsReception]. This ID is unique.
  set id(String? value);/// List of [AtsPurchaseOrder] IDs.
- List<String>? get ordersIds;/// List of [AtsPurchaseOrder] IDs.
- set ordersIds(List<String>? value);/// Diferent [AtsReceptionProductInput] obtained of the [AtsPurchaseOrder]
+@Deprecated('Use purchaseOrderIds instead') List<String>? get ordersIds;/// List of [AtsPurchaseOrder] IDs.
+@Deprecated('Use purchaseOrderIds instead') set ordersIds(List<String>? value);/// Diferent [AtsReceptionProductInput] obtained of the [AtsPurchaseOrder]
  List<AtsReceptionProductInput>? get products;/// Diferent [AtsReceptionProductInput] obtained of the [AtsPurchaseOrder]
  set products(List<AtsReceptionProductInput>? value);/// ID of the [Asset] supply point
  String? get assetId;/// ID of the [Asset] supply point
@@ -612,7 +612,9 @@ mixin _$AtsReceptionInput {
 @DurationOrNullConverter() Duration? get operationTime;/// [AtsReception] operation time
 @DurationOrNullConverter() set operationTime(Duration? value);/// App used to create the [AtsReception].
 @AtsFromAppOrNullConverter() AtsFromApp? get app;/// App used to create the [AtsReception].
-@AtsFromAppOrNullConverter() set app(AtsFromApp? value);
+@AtsFromAppOrNullConverter() set app(AtsFromApp? value);/// IDs of the [AtsPurchaseOrder]s.
+ List<String>? get purchaseOrderIds;/// IDs of the [AtsPurchaseOrder]s.
+ set purchaseOrderIds(List<String>? value);
 /// Create a copy of AtsReceptionInput
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -627,7 +629,7 @@ $AtsReceptionInputCopyWith<AtsReceptionInput> get copyWith => _$AtsReceptionInpu
 
 @override
 String toString() {
-  return 'AtsReceptionInput(id: $id, ordersIds: $ordersIds, products: $products, assetId: $assetId, operationTime: $operationTime, app: $app)';
+  return 'AtsReceptionInput(id: $id, ordersIds: $ordersIds, products: $products, assetId: $assetId, operationTime: $operationTime, app: $app, purchaseOrderIds: $purchaseOrderIds)';
 }
 
 
@@ -638,7 +640,7 @@ abstract mixin class $AtsReceptionInputCopyWith<$Res>  {
   factory $AtsReceptionInputCopyWith(AtsReceptionInput value, $Res Function(AtsReceptionInput) _then) = _$AtsReceptionInputCopyWithImpl;
 @useResult
 $Res call({
- String? id, List<String>? ordersIds, List<AtsReceptionProductInput>? products, String? assetId,@DurationOrNullConverter() Duration? operationTime,@AtsFromAppOrNullConverter() AtsFromApp? app
+ String? id,@Deprecated('Use purchaseOrderIds instead') List<String>? ordersIds, List<AtsReceptionProductInput>? products, String? assetId,@DurationOrNullConverter() Duration? operationTime,@AtsFromAppOrNullConverter() AtsFromApp? app, List<String>? purchaseOrderIds
 });
 
 
@@ -655,7 +657,7 @@ class _$AtsReceptionInputCopyWithImpl<$Res>
 
 /// Create a copy of AtsReceptionInput
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? ordersIds = freezed,Object? products = freezed,Object? assetId = freezed,Object? operationTime = freezed,Object? app = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? ordersIds = freezed,Object? products = freezed,Object? assetId = freezed,Object? operationTime = freezed,Object? app = freezed,Object? purchaseOrderIds = freezed,}) {
   return _then(_self.copyWith(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,ordersIds: freezed == ordersIds ? _self.ordersIds : ordersIds // ignore: cast_nullable_to_non_nullable
@@ -663,7 +665,8 @@ as List<String>?,products: freezed == products ? _self.products : products // ig
 as List<AtsReceptionProductInput>?,assetId: freezed == assetId ? _self.assetId : assetId // ignore: cast_nullable_to_non_nullable
 as String?,operationTime: freezed == operationTime ? _self.operationTime : operationTime // ignore: cast_nullable_to_non_nullable
 as Duration?,app: freezed == app ? _self.app : app // ignore: cast_nullable_to_non_nullable
-as AtsFromApp?,
+as AtsFromApp?,purchaseOrderIds: freezed == purchaseOrderIds ? _self.purchaseOrderIds : purchaseOrderIds // ignore: cast_nullable_to_non_nullable
+as List<String>?,
   ));
 }
 
@@ -748,10 +751,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  List<String>? ordersIds,  List<AtsReceptionProductInput>? products,  String? assetId, @DurationOrNullConverter()  Duration? operationTime, @AtsFromAppOrNullConverter()  AtsFromApp? app)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id, @Deprecated('Use purchaseOrderIds instead')  List<String>? ordersIds,  List<AtsReceptionProductInput>? products,  String? assetId, @DurationOrNullConverter()  Duration? operationTime, @AtsFromAppOrNullConverter()  AtsFromApp? app,  List<String>? purchaseOrderIds)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _AtsReceptionInput() when $default != null:
-return $default(_that.id,_that.ordersIds,_that.products,_that.assetId,_that.operationTime,_that.app);case _:
+return $default(_that.id,_that.ordersIds,_that.products,_that.assetId,_that.operationTime,_that.app,_that.purchaseOrderIds);case _:
   return orElse();
 
 }
@@ -769,10 +772,10 @@ return $default(_that.id,_that.ordersIds,_that.products,_that.assetId,_that.oper
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  List<String>? ordersIds,  List<AtsReceptionProductInput>? products,  String? assetId, @DurationOrNullConverter()  Duration? operationTime, @AtsFromAppOrNullConverter()  AtsFromApp? app)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id, @Deprecated('Use purchaseOrderIds instead')  List<String>? ordersIds,  List<AtsReceptionProductInput>? products,  String? assetId, @DurationOrNullConverter()  Duration? operationTime, @AtsFromAppOrNullConverter()  AtsFromApp? app,  List<String>? purchaseOrderIds)  $default,) {final _that = this;
 switch (_that) {
 case _AtsReceptionInput():
-return $default(_that.id,_that.ordersIds,_that.products,_that.assetId,_that.operationTime,_that.app);case _:
+return $default(_that.id,_that.ordersIds,_that.products,_that.assetId,_that.operationTime,_that.app,_that.purchaseOrderIds);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -789,10 +792,10 @@ return $default(_that.id,_that.ordersIds,_that.products,_that.assetId,_that.oper
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  List<String>? ordersIds,  List<AtsReceptionProductInput>? products,  String? assetId, @DurationOrNullConverter()  Duration? operationTime, @AtsFromAppOrNullConverter()  AtsFromApp? app)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id, @Deprecated('Use purchaseOrderIds instead')  List<String>? ordersIds,  List<AtsReceptionProductInput>? products,  String? assetId, @DurationOrNullConverter()  Duration? operationTime, @AtsFromAppOrNullConverter()  AtsFromApp? app,  List<String>? purchaseOrderIds)?  $default,) {final _that = this;
 switch (_that) {
 case _AtsReceptionInput() when $default != null:
-return $default(_that.id,_that.ordersIds,_that.products,_that.assetId,_that.operationTime,_that.app);case _:
+return $default(_that.id,_that.ordersIds,_that.products,_that.assetId,_that.operationTime,_that.app,_that.purchaseOrderIds);case _:
   return null;
 
 }
@@ -804,13 +807,13 @@ return $default(_that.id,_that.ordersIds,_that.products,_that.assetId,_that.oper
 @JsonSerializable()
 
 class _AtsReceptionInput implements AtsReceptionInput {
-   _AtsReceptionInput({this.id, this.ordersIds, this.products, this.assetId, @DurationOrNullConverter() this.operationTime, @AtsFromAppOrNullConverter() this.app});
+   _AtsReceptionInput({this.id, @Deprecated('Use purchaseOrderIds instead') this.ordersIds, this.products, this.assetId, @DurationOrNullConverter() this.operationTime, @AtsFromAppOrNullConverter() this.app, this.purchaseOrderIds});
   factory _AtsReceptionInput.fromJson(Map<String, dynamic> json) => _$AtsReceptionInputFromJson(json);
 
 ///ID of the [AtsReception]. This ID is unique.
 @override  String? id;
 /// List of [AtsPurchaseOrder] IDs.
-@override  List<String>? ordersIds;
+@override@Deprecated('Use purchaseOrderIds instead')  List<String>? ordersIds;
 /// Diferent [AtsReceptionProductInput] obtained of the [AtsPurchaseOrder]
 @override  List<AtsReceptionProductInput>? products;
 /// ID of the [Asset] supply point
@@ -819,6 +822,8 @@ class _AtsReceptionInput implements AtsReceptionInput {
 @override@DurationOrNullConverter()  Duration? operationTime;
 /// App used to create the [AtsReception].
 @override@AtsFromAppOrNullConverter()  AtsFromApp? app;
+/// IDs of the [AtsPurchaseOrder]s.
+@override  List<String>? purchaseOrderIds;
 
 /// Create a copy of AtsReceptionInput
 /// with the given fields replaced by the non-null parameter values.
@@ -835,7 +840,7 @@ Map<String, dynamic> toJson() {
 
 @override
 String toString() {
-  return 'AtsReceptionInput(id: $id, ordersIds: $ordersIds, products: $products, assetId: $assetId, operationTime: $operationTime, app: $app)';
+  return 'AtsReceptionInput(id: $id, ordersIds: $ordersIds, products: $products, assetId: $assetId, operationTime: $operationTime, app: $app, purchaseOrderIds: $purchaseOrderIds)';
 }
 
 
@@ -846,7 +851,7 @@ abstract mixin class _$AtsReceptionInputCopyWith<$Res> implements $AtsReceptionI
   factory _$AtsReceptionInputCopyWith(_AtsReceptionInput value, $Res Function(_AtsReceptionInput) _then) = __$AtsReceptionInputCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, List<String>? ordersIds, List<AtsReceptionProductInput>? products, String? assetId,@DurationOrNullConverter() Duration? operationTime,@AtsFromAppOrNullConverter() AtsFromApp? app
+ String? id,@Deprecated('Use purchaseOrderIds instead') List<String>? ordersIds, List<AtsReceptionProductInput>? products, String? assetId,@DurationOrNullConverter() Duration? operationTime,@AtsFromAppOrNullConverter() AtsFromApp? app, List<String>? purchaseOrderIds
 });
 
 
@@ -863,7 +868,7 @@ class __$AtsReceptionInputCopyWithImpl<$Res>
 
 /// Create a copy of AtsReceptionInput
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? ordersIds = freezed,Object? products = freezed,Object? assetId = freezed,Object? operationTime = freezed,Object? app = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? ordersIds = freezed,Object? products = freezed,Object? assetId = freezed,Object? operationTime = freezed,Object? app = freezed,Object? purchaseOrderIds = freezed,}) {
   return _then(_AtsReceptionInput(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,ordersIds: freezed == ordersIds ? _self.ordersIds : ordersIds // ignore: cast_nullable_to_non_nullable
@@ -871,7 +876,8 @@ as List<String>?,products: freezed == products ? _self.products : products // ig
 as List<AtsReceptionProductInput>?,assetId: freezed == assetId ? _self.assetId : assetId // ignore: cast_nullable_to_non_nullable
 as String?,operationTime: freezed == operationTime ? _self.operationTime : operationTime // ignore: cast_nullable_to_non_nullable
 as Duration?,app: freezed == app ? _self.app : app // ignore: cast_nullable_to_non_nullable
-as AtsFromApp?,
+as AtsFromApp?,purchaseOrderIds: freezed == purchaseOrderIds ? _self.purchaseOrderIds : purchaseOrderIds // ignore: cast_nullable_to_non_nullable
+as List<String>?,
   ));
 }
 

--- a/lib/src/ats/ats.g.dart
+++ b/lib/src/ats/ats.g.dart
@@ -83,6 +83,9 @@ _AtsReceptionInput _$AtsReceptionInputFromJson(Map<String, dynamic> json) =>
         json['operationTime'] as num?,
       ),
       app: const AtsFromAppOrNullConverter().fromJson(json['app'] as String?),
+      purchaseOrderIds: (json['purchaseOrderIds'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
     );
 
 Map<String, dynamic> _$AtsReceptionInputToJson(_AtsReceptionInput instance) =>
@@ -95,6 +98,7 @@ Map<String, dynamic> _$AtsReceptionInputToJson(_AtsReceptionInput instance) =>
         instance.operationTime,
       ),
       'app': const AtsFromAppOrNullConverter().toJson(instance.app),
+      'purchaseOrderIds': instance.purchaseOrderIds,
     };
 
 _AtsAuthenticationIdentifier _$AtsAuthenticationIdentifierFromJson(

--- a/lib/src/ats/src/reception/reception_product.dart
+++ b/lib/src/ats/src/reception/reception_product.dart
@@ -65,7 +65,7 @@ abstract class AtsReceptionInput with _$AtsReceptionInput {
     String? id,
 
     /// List of [AtsPurchaseOrder] IDs.
-    List<String>? ordersIds,
+    @Deprecated('Use purchaseOrderIds instead') List<String>? ordersIds,
 
     /// Diferent [AtsReceptionProductInput] obtained of the [AtsPurchaseOrder]
     List<AtsReceptionProductInput>? products,
@@ -78,6 +78,9 @@ abstract class AtsReceptionInput with _$AtsReceptionInput {
 
     /// App used to create the [AtsReception].
     @AtsFromAppOrNullConverter() AtsFromApp? app,
+
+    /// IDs of the [AtsPurchaseOrder]s.
+    List<String>? purchaseOrderIds,
   }) = _AtsReceptionInput;
 
   factory AtsReceptionInput.fromJson(Map<String, dynamic> json) => _$AtsReceptionInputFromJson(json);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.8.17"
+version: "3.8.18"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
- Added `purchaseOrderIds` field (`List<String>?`) to `AtsReceptionInput` to align with the GraphQL `ReceptionInput` schema.
- Deprecated `ordersIds` in favor of `purchaseOrderIds`.