### PR TITLE
fix(ats): update AtsFuelSubType colors for tank product reclassification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.10.4
+
+- Updated `AtsFuelSubType.getColor()` colors to match ATS tank product reclassification:
+  - Diesel S10 (`dieselS10A`, `dieselS10ComunB`, `dieselS10BAditivado`) changed to `#F0E1B4`.
+  - Ethanol (`ethanol`, `ethanolAditivado`) changed to `#2274D7`.
+
 ## 3.10.3
 
 - Added `tankAsset` field to `CaclEntity` model

--- a/lib/src/ats/src/enums/fuel_sub_type.dart
+++ b/lib/src/ats/src/enums/fuel_sub_type.dart
@@ -188,7 +188,7 @@ enum AtsFuelSubType {
       case AtsFuelSubType.dieselS10A:
       case AtsFuelSubType.dieselS10ComunB:
       case AtsFuelSubType.dieselS10BAditivado:
-        return const Color(0xffBEFA79);
+        return const Color(0xffF0E1B4);
       case AtsFuelSubType.gasolineComunA:
       case AtsFuelSubType.gasolineComunC:
       case AtsFuelSubType.gasolineCAditivada:
@@ -196,7 +196,7 @@ enum AtsFuelSubType {
         return const Color(0xFFF1C202);
       case AtsFuelSubType.ethanol:
       case AtsFuelSubType.ethanolAditivado:
-        return const Color(0xFFFFFFFF);
+        return const Color(0xFF2274D7);
       case AtsFuelSubType.biodieselB100:
         return const Color(0xFF016B2E);
       case AtsFuelSubType.anidro:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.10.3"
+version: "3.10.4"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
Diesel S10 changed to #F0E1B4 and Ethanol changed to #2274D7 to match the ATS tank product reclassification (ATSPV2-1220).