### PR TITLE
feat: add SensorDataType enum

### DIFF
--- a/lib/src/sensors/sensors.dart
+++ b/lib/src/sensors/sensors.dart
@@ -14,3 +14,4 @@ part 'src/range.dart';
 part 'src/mask.dart';
 part 'src/type.dart';
 part 'src/subtype.dart';
+part 'src/data_type.dart';

--- a/lib/src/sensors/sensors.g.dart
+++ b/lib/src/sensors/sensors.g.dart
@@ -277,3 +277,10 @@ Map<String, dynamic> _$MaskPointInputToJson(_MaskPointInput instance) =>
       'value': instance.value,
       'icon': const IconOrNullConverter().toJson(instance.icon),
     };
+
+const _$SensorDataTypeEnumMap = {
+  SensorDataType.integer: 'INT',
+  SensorDataType.float: 'FLOAT',
+  SensorDataType.string: 'STR',
+  SensorDataType.boolean: 'BOOL',
+};

--- a/lib/src/sensors/src/data_type.dart
+++ b/lib/src/sensors/src/data_type.dart
@@ -1,0 +1,35 @@
+part of '../sensors.dart';
+
+@JsonEnum(alwaysCreate: true)
+enum SensorDataType {
+  /// API reference: INT
+  /// Defines the data type as an integer.
+  @JsonValue('INT')
+  integer,
+
+  /// API reference: FLOAT
+  /// Defines the data type as a float.
+  @JsonValue('FLOAT')
+  float,
+
+  /// API reference: STR
+  /// Defines the data type as a string.
+  @JsonValue('STR')
+  string,
+
+  /// API reference: BOOL
+  /// Defines the data type as a boolean.
+  @JsonValue('BOOL')
+  boolean,
+  ;
+
+  @override
+  String toString() => toJson();
+
+  String toJson() => _$SensorDataTypeEnumMap[this] ?? 'STR';
+
+  static SensorDataType fromJson(String json) {
+    final value = _$SensorDataTypeEnumMap.entries.firstWhereOrNull((element) => element.value == json);
+    return value?.key ?? SensorDataType.string;
+  }
+}


### PR DESCRIPTION
## 📋 Summary

- Adds a new `SensorDataType` enum to the `sensors` library, representing a sensor value's primitive data type.
- Consumed by the sensor value override feature in `layrz_assets`.

## 📝 Changes

### ✨ Features
- New `SensorDataType` enum (`INT` / `FLOAT` / `STR` / `BOOL`) in `lib/src/sensors/src/data_type.dart`, following the existing `SensorType` / `ReportDataType` pattern (`@JsonEnum` + `@JsonValue`, with `toJson`/`fromJson` helpers).
- Registered the part in the `sensors` barrel and regenerated codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)