### PR TITLE
chore: release 3.10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.10.11
+- Added `SensorDataType` enum (`INT`, `FLOAT`, `STR`, `BOOL`) to the `sensors` module.
+
 ## 3.10.10
 - Added `MessageOfTheDay` and `MessageOfTheDayInput` models to the `brickhouse` module.
 

--- a/lib/src/sensors/sensors.dart
+++ b/lib/src/sensors/sensors.dart
@@ -14,3 +14,4 @@ part 'src/range.dart';
 part 'src/mask.dart';
 part 'src/type.dart';
 part 'src/subtype.dart';
+part 'src/data_type.dart';

--- a/lib/src/sensors/sensors.g.dart
+++ b/lib/src/sensors/sensors.g.dart
@@ -277,3 +277,10 @@ Map<String, dynamic> _$MaskPointInputToJson(_MaskPointInput instance) =>
       'value': instance.value,
       'icon': const IconOrNullConverter().toJson(instance.icon),
     };
+
+const _$SensorDataTypeEnumMap = {
+  SensorDataType.integer: 'INT',
+  SensorDataType.float: 'FLOAT',
+  SensorDataType.string: 'STR',
+  SensorDataType.boolean: 'BOOL',
+};

--- a/lib/src/sensors/src/data_type.dart
+++ b/lib/src/sensors/src/data_type.dart
@@ -1,0 +1,35 @@
+part of '../sensors.dart';
+
+@JsonEnum(alwaysCreate: true)
+enum SensorDataType {
+  /// API reference: INT
+  /// Defines the data type as an integer.
+  @JsonValue('INT')
+  integer,
+
+  /// API reference: FLOAT
+  /// Defines the data type as a float.
+  @JsonValue('FLOAT')
+  float,
+
+  /// API reference: STR
+  /// Defines the data type as a string.
+  @JsonValue('STR')
+  string,
+
+  /// API reference: BOOL
+  /// Defines the data type as a boolean.
+  @JsonValue('BOOL')
+  boolean,
+  ;
+
+  @override
+  String toString() => toJson();
+
+  String toJson() => _$SensorDataTypeEnumMap[this] ?? 'STR';
+
+  static SensorDataType fromJson(String json) {
+    final value = _$SensorDataTypeEnumMap.entries.firstWhereOrNull((element) => element.value == json);
+    return value?.key ?? SensorDataType.string;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.10.10"
+version: "3.10.11"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
## 📋 Summary

- Release `3.10.11`.
- Adds the `SensorDataType` enum to the `sensors` module, consumed by the sensor value override feature in `layrz_assets`.

## 📝 Changes

### ✨ Features
- New `SensorDataType` enum (`INT`, `FLOAT`, `STR`, `BOOL`) in the `sensors` module.

### 🔧 Chore / Config
- Bump version to `3.10.11` and update `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)