### PR TITLE
chore: release v3.11.0

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: goldenm-software/layrz-actions/.github/actions/check-dart@v1
         with:
-          flutter-version: "3.41.9"
+          flutter-version: "3.44.2"
           run-tests: true
 
   coverage-comment:
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dart-coverage-${{ github.run_id }}
           path: dart-coverage

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: flutter-actions/setup-flutter@v4
         with:
           channel: stable
-          version: 3.41.6
+          version: 3.44.2
           cache: true
           cache-sdk: true
           cache-key: ${{ runner.os }}-flutter-${{ hashFiles('pubspec.yaml') }}
@@ -105,7 +105,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: Release ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.changelog }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.11.0
+
+- Bumped minimum SDK constraints to Dart `>=3.12.0` and Flutter `>=3.44.0`
+- Upgraded `layrz_icons` dependency to `^1.1.0`
+- Updated `mobilePopupNotification` icon in `OperationType` to `solarOutlineSmartphoneN2`
+
 ## 3.10.16
 
 - Added `duration` field (`Duration?`) to `MaskPoint` and `MaskPointInput` models, with `@DurationConverter()` for JSON serialization/deserialization.

--- a/lib/src/operations/src/operation_type.dart
+++ b/lib/src/operations/src/operation_type.dart
@@ -119,7 +119,7 @@ enum OperationType {
         return LayrzIcons.solarOutlinePhoneCallingRounded;
 
       case .mobilePopupNotification:
-        return LayrzIcons.solarOutlineSmartphone2;
+        return LayrzIcons.solarOutlineSmartphoneN2;
 
       case .bhsPush:
         return LayrzIcons.mdiFirebase;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.10.16"
+version: "3.11.0"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.1"
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:
@@ -18,7 +18,7 @@ dependencies:
   collection: ^1.18.0
   recase: ^4.1.0
   latlong2: ^0.9.1
-  layrz_icons: ^1.0.3
+  layrz_icons: ^1.1.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.11.0
   layrz_logging: ^1.2.1


### PR DESCRIPTION
## 📋 Summary

- Release **v3.11.0** of `layrz_models`
- Raises minimum SDK floors and upgrades the `layrz_icons` dependency, with one corresponding icon rename

## 📝 Changes

### 🔧 Chore / Config
- Bumped minimum SDK constraints to Dart `>=3.12.0` and Flutter `>=3.44.0`
- Upgraded `layrz_icons` dependency to `^1.1.0`
- Updated `mobilePopupNotification` icon in `OperationType` to `solarOutlineSmartphoneN2`
- Bumped package version to `3.11.0` and updated `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)