### PR TITLE
fix(workspace): handle null icon in WorkspaceInput.fromJson

### DIFF
--- a/lib/src/workspace/workspace.g.dart
+++ b/lib/src/workspace/workspace.g.dart
@@ -255,7 +255,7 @@ _WorkspaceInput _$WorkspaceInputFromJson(
   color: json['color'] == null
       ? Colors.blue
       : const ColorOrNullConverter().fromJson(json['color'] as String?),
-  icon: const IconConverter().fromJson(json['icon'] as String),
+  icon: const IconOrNullConverter().fromJson(json['icon'] as String?) ?? LayrzIconsClasses.solarOutlineQuestionSquare,
   background: json['background'] as String?,
   isFavorite: json['isFavorite'] as bool? ?? false,
   mainView:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.11.7"
+version: "3.11.8"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
Use IconOrNullConverter with a safe fallback when the workspace icon field is null, preventing a cast crash during JSON round-trip.