### PR TITLE
feat: Add constant.number structure type for ATAK outbound services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.13.1
+
+- Added `constant.number` value to `AtsStreamExitStructureType` enum, a sibling of `constant` for ATAK outbound structure entries whose `value` should be sent as a real JSON number instead of a string.
+
 ## 3.13.0
 
 - Added `ActionType.zigbeeChange` (`ZIGBEE_CHANGE`) plus the `ActionZigbeeSetting`, `ActionZigbeeSettings` and `ActionZigbeeSettingsInput` models, with a new `zigbeeSettings` field on `Action` and `ActionInput`.

--- a/lib/src/ats/ats.g.dart
+++ b/lib/src/ats/ats.g.dart
@@ -3503,6 +3503,7 @@ const _$AtsStreamModelEnumMap = {AtsStreamModel.exit: 'EXIT'};
 
 const _$AtsStreamExitStructureTypeEnumMap = {
   AtsStreamExitStructureType.constant: 'constant',
+  AtsStreamExitStructureType.constantNumber: 'constant.number',
   AtsStreamExitStructureType.fromAssetName: 'fromAsset.name',
   AtsStreamExitStructureType.fromAssetVin: 'fromAsset.vin',
   AtsStreamExitStructureType.fromAssetPlate: 'fromAsset.plate',

--- a/lib/src/ats/src/ats_outbound_services/ats_stream_exit.dart
+++ b/lib/src/ats/src/ats_outbound_services/ats_stream_exit.dart
@@ -6,9 +6,14 @@ part of '../../ats.dart';
 /// To validate that, you can use the [AtsStreamExitStructureType.isCustom(String)] static method.
 @JsonEnum(alwaysCreate: true)
 enum AtsStreamExitStructureType {
-  /// Layrz API equivalence: `constant`. Means a constant value
+  /// Layrz API equivalence: `constant`. Means a constant value, always sent as a string.
   @JsonValue('constant')
   constant,
+
+  /// Layrz API equivalence: `constant.number`. Means a constant value, sent as a real number
+  /// instead of a string. `value` must be a string that parses as a number (e.g. `1898`, `12.5`).
+  @JsonValue('constant.number')
+  constantNumber,
 
   /// Layrz API equivalence: `fromAsset.name`. Means the name of the asset that is being moved.
   @JsonValue('fromAsset.name')

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.13.0"
+version: "3.13.1"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
Added `constant.number` to AtsStreamExitStructureType, a sibling of `constant` for entries whose value should be sent as a real JSON number instead of a string. Backend validates that `value` parses as a number at save time (error code invalidNumber).

Bumped version to 3.13.1 and updated changelog.