### PR TITLE
Make performedBy nullable in MappitRouteLinkingHistory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ mapper.py
 .vscode/settings.json
 
 .claude/settings.local.json
+
+# Local tooling
+.atl/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 3.13.2
+## 3.13.3
 
 - Made `performedBy` nullable (`User?`) in `MappitRouteLinkingHistory`. When an employee is removed, the relation is soft-deleted and the backend sends `performedBy: null` for historical records, while `performedById` still holds the plain ID. The previous non-nullable declaration crashed `fromJson` with `type 'Null' is not a subtype of type 'Map<String, dynamic>'`. This aligns `performedBy` with the already-nullable `currentSeller` field.
+
+## 3.13.2
+
+- Never published to pub.dev. The release tag was created off the `development` branch before it merged into `main`, so the publish workflow rejected it. The `performedBy` fix above was re-released as `3.13.3`.
 
 ## 3.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.13.2
+
+- Made `performedBy` nullable (`User?`) in `MappitRouteLinkingHistory`. When an employee is removed, the relation is soft-deleted and the backend sends `performedBy: null` for historical records, while `performedById` still holds the plain ID. The previous non-nullable declaration crashed `fromJson` with `type 'Null' is not a subtype of type 'Map<String, dynamic>'`. This aligns `performedBy` with the already-nullable `currentSeller` field.
+
 ## 3.13.1
 
 - Added `constant.number` value to `AtsStreamExitStructureType` enum, a sibling of `constant` for ATAK outbound structure entries whose `value` should be sent as a real JSON number instead of a string.

--- a/lib/src/mappit/mappit.freezed.dart
+++ b/lib/src/mappit/mappit.freezed.dart
@@ -17,8 +17,10 @@ mixin _$MappitRouteLinkingHistory {
 
 /// [currentSeller] represents the current seller of the route. If this field comes null, means is a unlink
  Asset? get currentSeller;/// [currentSellerId] represents the current seller ID of the route. If this field comes null, means is a unlink
- String? get currentSellerId;/// [performedBy] represents the user that performed the operation of link or unlink
- User get performedBy;/// [performedById] represents the user ID that performed the operation of link or unlink
+ String? get currentSellerId;/// [performedBy] represents the user that performed the operation of link or unlink.
+/// If this field comes null, the relation was soft-deleted (e.g. the user was removed);
+/// [performedById] still holds the plain ID of who performed the operation.
+ User? get performedBy;/// [performedById] represents the user ID that performed the operation of link or unlink
  String get performedById;/// [performedAt] is the timestamp of the operation
 @TimestampConverter() DateTime get performedAt;
 /// Create a copy of MappitRouteLinkingHistory
@@ -53,11 +55,11 @@ abstract mixin class $MappitRouteLinkingHistoryCopyWith<$Res>  {
   factory $MappitRouteLinkingHistoryCopyWith(MappitRouteLinkingHistory value, $Res Function(MappitRouteLinkingHistory) _then) = _$MappitRouteLinkingHistoryCopyWithImpl;
 @useResult
 $Res call({
- Asset? currentSeller, String? currentSellerId, User performedBy, String performedById,@TimestampConverter() DateTime performedAt
+ Asset? currentSeller, String? currentSellerId, User? performedBy, String performedById,@TimestampConverter() DateTime performedAt
 });
 
 
-$AssetCopyWith<$Res>? get currentSeller;$UserCopyWith<$Res> get performedBy;
+$AssetCopyWith<$Res>? get currentSeller;$UserCopyWith<$Res>? get performedBy;
 
 }
 /// @nodoc
@@ -70,12 +72,12 @@ class _$MappitRouteLinkingHistoryCopyWithImpl<$Res>
 
 /// Create a copy of MappitRouteLinkingHistory
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? currentSeller = freezed,Object? currentSellerId = freezed,Object? performedBy = null,Object? performedById = null,Object? performedAt = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? currentSeller = freezed,Object? currentSellerId = freezed,Object? performedBy = freezed,Object? performedById = null,Object? performedAt = null,}) {
   return _then(_self.copyWith(
 currentSeller: freezed == currentSeller ? _self.currentSeller : currentSeller // ignore: cast_nullable_to_non_nullable
 as Asset?,currentSellerId: freezed == currentSellerId ? _self.currentSellerId : currentSellerId // ignore: cast_nullable_to_non_nullable
-as String?,performedBy: null == performedBy ? _self.performedBy : performedBy // ignore: cast_nullable_to_non_nullable
-as User,performedById: null == performedById ? _self.performedById : performedById // ignore: cast_nullable_to_non_nullable
+as String?,performedBy: freezed == performedBy ? _self.performedBy : performedBy // ignore: cast_nullable_to_non_nullable
+as User?,performedById: null == performedById ? _self.performedById : performedById // ignore: cast_nullable_to_non_nullable
 as String,performedAt: null == performedAt ? _self.performedAt : performedAt // ignore: cast_nullable_to_non_nullable
 as DateTime,
   ));
@@ -96,9 +98,12 @@ $AssetCopyWith<$Res>? get currentSeller {
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$UserCopyWith<$Res> get performedBy {
-  
-  return $UserCopyWith<$Res>(_self.performedBy, (value) {
+$UserCopyWith<$Res>? get performedBy {
+    if (_self.performedBy == null) {
+    return null;
+  }
+
+  return $UserCopyWith<$Res>(_self.performedBy!, (value) {
     return _then(_self.copyWith(performedBy: value));
   });
 }
@@ -183,7 +188,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Asset? currentSeller,  String? currentSellerId,  User performedBy,  String performedById, @TimestampConverter()  DateTime performedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Asset? currentSeller,  String? currentSellerId,  User? performedBy,  String performedById, @TimestampConverter()  DateTime performedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MappitRouteLinkingHistory() when $default != null:
 return $default(_that.currentSeller,_that.currentSellerId,_that.performedBy,_that.performedById,_that.performedAt);case _:
@@ -204,7 +209,7 @@ return $default(_that.currentSeller,_that.currentSellerId,_that.performedBy,_tha
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Asset? currentSeller,  String? currentSellerId,  User performedBy,  String performedById, @TimestampConverter()  DateTime performedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Asset? currentSeller,  String? currentSellerId,  User? performedBy,  String performedById, @TimestampConverter()  DateTime performedAt)  $default,) {final _that = this;
 switch (_that) {
 case _MappitRouteLinkingHistory():
 return $default(_that.currentSeller,_that.currentSellerId,_that.performedBy,_that.performedById,_that.performedAt);case _:
@@ -224,7 +229,7 @@ return $default(_that.currentSeller,_that.currentSellerId,_that.performedBy,_tha
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Asset? currentSeller,  String? currentSellerId,  User performedBy,  String performedById, @TimestampConverter()  DateTime performedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Asset? currentSeller,  String? currentSellerId,  User? performedBy,  String performedById, @TimestampConverter()  DateTime performedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _MappitRouteLinkingHistory() when $default != null:
 return $default(_that.currentSeller,_that.currentSellerId,_that.performedBy,_that.performedById,_that.performedAt);case _:
@@ -239,15 +244,17 @@ return $default(_that.currentSeller,_that.currentSellerId,_that.performedBy,_tha
 @JsonSerializable()
 
 class _MappitRouteLinkingHistory implements MappitRouteLinkingHistory {
-  const _MappitRouteLinkingHistory({this.currentSeller, this.currentSellerId, required this.performedBy, required this.performedById, @TimestampConverter() required this.performedAt});
+  const _MappitRouteLinkingHistory({this.currentSeller, this.currentSellerId, this.performedBy, required this.performedById, @TimestampConverter() required this.performedAt});
   factory _MappitRouteLinkingHistory.fromJson(Map<String, dynamic> json) => _$MappitRouteLinkingHistoryFromJson(json);
 
 /// [currentSeller] represents the current seller of the route. If this field comes null, means is a unlink
 @override final  Asset? currentSeller;
 /// [currentSellerId] represents the current seller ID of the route. If this field comes null, means is a unlink
 @override final  String? currentSellerId;
-/// [performedBy] represents the user that performed the operation of link or unlink
-@override final  User performedBy;
+/// [performedBy] represents the user that performed the operation of link or unlink.
+/// If this field comes null, the relation was soft-deleted (e.g. the user was removed);
+/// [performedById] still holds the plain ID of who performed the operation.
+@override final  User? performedBy;
 /// [performedById] represents the user ID that performed the operation of link or unlink
 @override final  String performedById;
 /// [performedAt] is the timestamp of the operation
@@ -286,11 +293,11 @@ abstract mixin class _$MappitRouteLinkingHistoryCopyWith<$Res> implements $Mappi
   factory _$MappitRouteLinkingHistoryCopyWith(_MappitRouteLinkingHistory value, $Res Function(_MappitRouteLinkingHistory) _then) = __$MappitRouteLinkingHistoryCopyWithImpl;
 @override @useResult
 $Res call({
- Asset? currentSeller, String? currentSellerId, User performedBy, String performedById,@TimestampConverter() DateTime performedAt
+ Asset? currentSeller, String? currentSellerId, User? performedBy, String performedById,@TimestampConverter() DateTime performedAt
 });
 
 
-@override $AssetCopyWith<$Res>? get currentSeller;@override $UserCopyWith<$Res> get performedBy;
+@override $AssetCopyWith<$Res>? get currentSeller;@override $UserCopyWith<$Res>? get performedBy;
 
 }
 /// @nodoc
@@ -303,12 +310,12 @@ class __$MappitRouteLinkingHistoryCopyWithImpl<$Res>
 
 /// Create a copy of MappitRouteLinkingHistory
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? currentSeller = freezed,Object? currentSellerId = freezed,Object? performedBy = null,Object? performedById = null,Object? performedAt = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? currentSeller = freezed,Object? currentSellerId = freezed,Object? performedBy = freezed,Object? performedById = null,Object? performedAt = null,}) {
   return _then(_MappitRouteLinkingHistory(
 currentSeller: freezed == currentSeller ? _self.currentSeller : currentSeller // ignore: cast_nullable_to_non_nullable
 as Asset?,currentSellerId: freezed == currentSellerId ? _self.currentSellerId : currentSellerId // ignore: cast_nullable_to_non_nullable
-as String?,performedBy: null == performedBy ? _self.performedBy : performedBy // ignore: cast_nullable_to_non_nullable
-as User,performedById: null == performedById ? _self.performedById : performedById // ignore: cast_nullable_to_non_nullable
+as String?,performedBy: freezed == performedBy ? _self.performedBy : performedBy // ignore: cast_nullable_to_non_nullable
+as User?,performedById: null == performedById ? _self.performedById : performedById // ignore: cast_nullable_to_non_nullable
 as String,performedAt: null == performedAt ? _self.performedAt : performedAt // ignore: cast_nullable_to_non_nullable
 as DateTime,
   ));
@@ -330,9 +337,12 @@ $AssetCopyWith<$Res>? get currentSeller {
 /// with the given fields replaced by the non-null parameter values.
 @override
 @pragma('vm:prefer-inline')
-$UserCopyWith<$Res> get performedBy {
-  
-  return $UserCopyWith<$Res>(_self.performedBy, (value) {
+$UserCopyWith<$Res>? get performedBy {
+    if (_self.performedBy == null) {
+    return null;
+  }
+
+  return $UserCopyWith<$Res>(_self.performedBy!, (value) {
     return _then(_self.copyWith(performedBy: value));
   });
 }

--- a/lib/src/mappit/mappit.g.dart
+++ b/lib/src/mappit/mappit.g.dart
@@ -13,7 +13,9 @@ _MappitRouteLinkingHistory _$MappitRouteLinkingHistoryFromJson(
       ? null
       : Asset.fromJson(json['currentSeller'] as Map<String, dynamic>),
   currentSellerId: json['currentSellerId'] as String?,
-  performedBy: User.fromJson(json['performedBy'] as Map<String, dynamic>),
+  performedBy: json['performedBy'] == null
+      ? null
+      : User.fromJson(json['performedBy'] as Map<String, dynamic>),
   performedById: json['performedById'] as String,
   performedAt: const TimestampConverter().fromJson(json['performedAt'] as num),
 );
@@ -23,7 +25,7 @@ Map<String, dynamic> _$MappitRouteLinkingHistoryToJson(
 ) => <String, dynamic>{
   'currentSeller': instance.currentSeller?.toJson(),
   'currentSellerId': instance.currentSellerId,
-  'performedBy': instance.performedBy.toJson(),
+  'performedBy': instance.performedBy?.toJson(),
   'performedById': instance.performedById,
   'performedAt': const TimestampConverter().toJson(instance.performedAt),
 };

--- a/lib/src/mappit/src/route.dart
+++ b/lib/src/mappit/src/route.dart
@@ -9,8 +9,10 @@ abstract class MappitRouteLinkingHistory with _$MappitRouteLinkingHistory {
     /// [currentSellerId] represents the current seller ID of the route. If this field comes null, means is a unlink
     String? currentSellerId,
 
-    /// [performedBy] represents the user that performed the operation of link or unlink
-    required User performedBy,
+    /// [performedBy] represents the user that performed the operation of link or unlink.
+    /// If this field comes null, the relation was soft-deleted (e.g. the user was removed);
+    /// [performedById] still holds the plain ID of who performed the operation.
+    User? performedBy,
 
     /// [performedById] represents the user ID that performed the operation of link or unlink
     required String performedById,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.13.1"
+version: "3.13.2"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.13.2"
+version: "3.13.3"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
This pull request updates the `MappitRouteLinkingHistory` model to make the `performedBy` field nullable throughout the codebase. This change ensures the app can handle cases where the user who performed a route link/unlink operation has been removed (soft-deleted), preventing crashes during JSON deserialization. The update also improves documentation and aligns the model with backend behavior.

**Model changes:**

* Made the `performedBy` field in `MappitRouteLinkingHistory` nullable (`User?` instead of `User`), with updated documentation to explain that `performedById` will still hold the user ID if the user is removed. (`lib/src/mappit/src/route.dart`, `lib/src/mappit/mappit.freezed.dart`) [[1]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L20-R23) [[2]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L242-R257) [[3]](diffhunk://#diff-b153be69da24cdf2e792ecbb68c884e866e915efacd06e0413d6b0baa34fc0ceL12-R15)
* Updated all code generation, copyWith methods, and constructor signatures to support a nullable `performedBy` field. (`lib/src/mappit/mappit.freezed.dart`) [[1]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L56-R62) [[2]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L73-R80) [[3]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L99-R106) [[4]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L186-R191) [[5]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L207-R212) [[6]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L227-R232) [[7]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L289-R300) [[8]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L306-R318) [[9]](diffhunk://#diff-d55e392a42d4c982af30e5395674217f5da7465a13dc4b25118e30c79e3c1f64L333-R345)

**Serialization/deserialization:**

* Updated JSON serialization and deserialization logic to correctly handle cases where `performedBy` is `null`. (`lib/src/mappit/mappit.g.dart`) [[1]](diffhunk://#diff-1ebec3cb37347d73669f23ab8ea6af063398008b2958184b5215e128982fa771L16-R18) [[2]](diffhunk://#diff-1ebec3cb37347d73669f23ab8ea6af063398008b2958184b5215e128982fa771L26-R28)

**Documentation and versioning:**

* Updated the `CHANGELOG.md` to document this change and explain the motivation. (`CHANGELOG.md`)
* Bumped the package version to `3.13.2` in `pubspec.yaml`. (`pubspec.yaml`)