### PR TITLE
Release 3.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.16.0
+
+- Add `PushDevice` model with `validate()` API caller to check device registration status on the backend and retrieve associated operation IDs
+- Add `PushDevice.register()` to register a new push device for an app and retrieve the created device ID
+- Add `PushDevice.bindOperations()` to bind or unbind a list of operations to a push device
+- Add `PushDevice.deregister()` to deregister a push device by its ID
+
 ## 3.15.2
 
 - Fix Operation GraphQL fragment: query `accountId` instead of `externalAccountId`, remove unexposed `emailTemplateId`, align `access` sub-selection with AccessPermission schema (id, read, write, manage, objectId, userId, module)

--- a/lib/src/app/app.dart
+++ b/lib/src/app/app.dart
@@ -22,6 +22,7 @@ part 'src/instance.dart';
 part 'src/legal.dart';
 part 'src/login.dart';
 part 'src/push_secrets.dart';
+part 'src/push_device.dart';
 part 'src/version.dart';
 part 'src/font.dart';
 

--- a/lib/src/app/app.freezed.dart
+++ b/lib/src/app/app.freezed.dart
@@ -6337,6 +6337,281 @@ as String?,
 
 
 /// @nodoc
+mixin _$PushDevice {
+
+/// [id] is the unique identifier of the push device (UUID string).
+ String get id;/// [appId] is the ID of the registered app this device is associated with.
+ String? get appId;/// [createdAt] is the timestamp when the device was registered.
+@TimestampOrNullConverter() DateTime? get createdAt;
+/// Create a copy of PushDevice
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PushDeviceCopyWith<PushDevice> get copyWith => _$PushDeviceCopyWithImpl<PushDevice>(this as PushDevice, _$identity);
+
+  /// Serializes this PushDevice to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PushDevice&&(identical(other.id, id) || other.id == id)&&(identical(other.appId, appId) || other.appId == appId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,appId,createdAt);
+
+@override
+String toString() {
+  return 'PushDevice(id: $id, appId: $appId, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PushDeviceCopyWith<$Res>  {
+  factory $PushDeviceCopyWith(PushDevice value, $Res Function(PushDevice) _then) = _$PushDeviceCopyWithImpl;
+@useResult
+$Res call({
+ String id, String? appId,@TimestampOrNullConverter() DateTime? createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$PushDeviceCopyWithImpl<$Res>
+    implements $PushDeviceCopyWith<$Res> {
+  _$PushDeviceCopyWithImpl(this._self, this._then);
+
+  final PushDevice _self;
+  final $Res Function(PushDevice) _then;
+
+/// Create a copy of PushDevice
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? appId = freezed,Object? createdAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,appId: freezed == appId ? _self.appId : appId // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [PushDevice].
+extension PushDevicePatterns on PushDevice {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PushDevice value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PushDevice() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PushDevice value)  $default,){
+final _that = this;
+switch (_that) {
+case _PushDevice():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PushDevice value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PushDevice() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String? appId, @TimestampOrNullConverter()  DateTime? createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PushDevice() when $default != null:
+return $default(_that.id,_that.appId,_that.createdAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String? appId, @TimestampOrNullConverter()  DateTime? createdAt)  $default,) {final _that = this;
+switch (_that) {
+case _PushDevice():
+return $default(_that.id,_that.appId,_that.createdAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String? appId, @TimestampOrNullConverter()  DateTime? createdAt)?  $default,) {final _that = this;
+switch (_that) {
+case _PushDevice() when $default != null:
+return $default(_that.id,_that.appId,_that.createdAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _PushDevice implements PushDevice {
+  const _PushDevice({required this.id, this.appId, @TimestampOrNullConverter() this.createdAt});
+  factory _PushDevice.fromJson(Map<String, dynamic> json) => _$PushDeviceFromJson(json);
+
+/// [id] is the unique identifier of the push device (UUID string).
+@override final  String id;
+/// [appId] is the ID of the registered app this device is associated with.
+@override final  String? appId;
+/// [createdAt] is the timestamp when the device was registered.
+@override@TimestampOrNullConverter() final  DateTime? createdAt;
+
+/// Create a copy of PushDevice
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PushDeviceCopyWith<_PushDevice> get copyWith => __$PushDeviceCopyWithImpl<_PushDevice>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PushDeviceToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PushDevice&&(identical(other.id, id) || other.id == id)&&(identical(other.appId, appId) || other.appId == appId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,appId,createdAt);
+
+@override
+String toString() {
+  return 'PushDevice(id: $id, appId: $appId, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PushDeviceCopyWith<$Res> implements $PushDeviceCopyWith<$Res> {
+  factory _$PushDeviceCopyWith(_PushDevice value, $Res Function(_PushDevice) _then) = __$PushDeviceCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String? appId,@TimestampOrNullConverter() DateTime? createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$PushDeviceCopyWithImpl<$Res>
+    implements _$PushDeviceCopyWith<$Res> {
+  __$PushDeviceCopyWithImpl(this._self, this._then);
+
+  final _PushDevice _self;
+  final $Res Function(_PushDevice) _then;
+
+/// Create a copy of PushDevice
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? appId = freezed,Object? createdAt = freezed,}) {
+  return _then(_PushDevice(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,appId: freezed == appId ? _self.appId : appId // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
 mixin _$AppVersion {
 
  String get id;@JsonKey(unknownEnumValue: AppInternalIdentifier.unknown) AppInternalIdentifier? get app;@JsonKey(unknownEnumValue: AppPlatform.web) AppPlatform? get platform; String? get fileUri; int get buildNumber; String get buildName;@TimestampConverter() DateTime get releasedAt;

--- a/lib/src/app/app.g.dart
+++ b/lib/src/app/app.g.dart
@@ -657,6 +657,21 @@ Map<String, dynamic> _$PushSecretsInputToJson(_PushSecretsInput instance) =>
       'storageBucket': instance.storageBucket,
     };
 
+_PushDevice _$PushDeviceFromJson(Map<String, dynamic> json) => _PushDevice(
+  id: json['id'] as String,
+  appId: json['appId'] as String?,
+  createdAt: const TimestampOrNullConverter().fromJson(
+    json['createdAt'] as num?,
+  ),
+);
+
+Map<String, dynamic> _$PushDeviceToJson(_PushDevice instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'appId': instance.appId,
+      'createdAt': const TimestampOrNullConverter().toJson(instance.createdAt),
+    };
+
 _AppVersion _$AppVersionFromJson(Map<String, dynamic> json) => _AppVersion(
   id: json['id'] as String,
   app: $enumDecodeNullable(

--- a/lib/src/app/src/push_device.dart
+++ b/lib/src/app/src/push_device.dart
@@ -1,0 +1,294 @@
+part of '../app.dart';
+
+/// [PushDevice] represents a push notification device registered with the backend.
+/// It stores the device identifier, associated app, and when it was registered.
+@freezed
+abstract class PushDevice with _$PushDevice {
+  const factory PushDevice({
+    /// [id] is the unique identifier of the push device (UUID string).
+    required String id,
+
+    /// [appId] is the ID of the registered app this device is associated with.
+    String? appId,
+
+    /// [createdAt] is the timestamp when the device was registered.
+    @TimestampOrNullConverter() DateTime? createdAt,
+  }) = _PushDevice;
+
+  factory PushDevice.fromJson(Map<String, dynamic> json) => _$PushDeviceFromJson(json);
+
+  /// [gqlFragment] is the GraphQL fragment for [PushDevice].
+  static GqlFragment get gqlFragment => GqlFragment(name: 'pushDeviceFragment', onType: 'PushDevice')
+    ..add(GqlField(name: 'id'))
+    ..add(GqlField(name: 'appId'))
+    ..add(GqlField(name: 'createdAt'));
+
+  /// [validate] validates a push device by its ID against the backend.
+  /// Returns a [PushDeviceValidation] on success containing the device and operation IDs,
+  /// or null if the device does not exist or if a network error occurs.
+  /// Call [onResponse] with the status code so the caller can distinguish NOT_FOUND
+  /// (device gone → wipe local state) from transient errors.
+  static Future<PushDeviceValidation?> validate({
+    /// [deviceId] is the ID of the device to validate (UUID string).
+    required String deviceId,
+
+    /// [apiToken] is the API token to use for authentication.
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use.
+    required Uri uri,
+
+    /// [onResponse] is an optional callback invoked with the status code.
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.perform(
+        GqlQuery(
+          variables: [
+            GqlVariable(name: 'deviceId', type: .id, isRequired: true, value: deviceId),
+          ],
+          name: 'validatePushDevice',
+        )..add(
+          GqlField(name: 'validatePushDevice', args: {'deviceId': 'deviceId'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: gqlFragment))
+            ..add(GqlField(name: 'operationIds')),
+        ),
+      );
+
+      final data = response.data;
+      if (data == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/PushDevice/validate(): No response from server");
+        return null;
+      }
+
+      final result = data['data']['validatePushDevice'];
+      if (result == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/PushDevice/validate(): No result from server");
+        return null;
+      }
+
+      final status = ApiStatus.fromJson(result['status']);
+      onResponse?.call(status.toJson());
+
+      if (status != ApiStatus.ok) {
+        return null;
+      }
+
+      final deviceJson = result['result'] as Map<String, dynamic>?;
+      if (deviceJson == null) {
+        Log.warning("layrz_models/PushDevice/validate(): No device in result");
+        return null;
+      }
+
+      final device = PushDevice.fromJson(deviceJson);
+      final operationIds = (result['operationIds'] as List<dynamic>?)?.map((e) => e as String).toList() ?? [];
+
+      return PushDeviceValidation(device: device, operationIds: operationIds);
+    } catch (e, stack) {
+      Log.critical("layrz_models/PushDevice/validate(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+
+  /// [register] registers a new push device for the given app.
+  /// Returns the created device ID (String) on success, or null on failure.
+  /// Call [onResponse] with the status code to distinguish error types.
+  static Future<String?> register({
+    /// [appId] is the ID of the registered app to register the device for.
+    required String appId,
+
+    /// [apiToken] is the API token to use for authentication.
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use.
+    required Uri uri,
+
+    /// [onResponse] is an optional callback invoked with the status code.
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.perform(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'appId', type: .id, isRequired: true, value: appId),
+          ],
+          name: 'registerPushDevice',
+        )..add(
+          GqlField(name: 'registerPushDevice', args: {'appId': 'appId'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result')),
+        ),
+      );
+
+      final data = response.data;
+      if (data == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/PushDevice/register(): No response from server");
+        return null;
+      }
+
+      final result = data['data']['registerPushDevice'];
+      if (result == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/PushDevice/register(): No result from server");
+        return null;
+      }
+
+      final status = ApiStatus.fromJson(result['status']);
+      onResponse?.call(status.toJson());
+
+      if (status != ApiStatus.ok) {
+        return null;
+      }
+
+      final deviceId = result['result'] as String?;
+      if (deviceId == null) {
+        Log.warning("layrz_models/PushDevice/register(): Device ID missing in result");
+        return null;
+      }
+
+      return deviceId;
+    } catch (e, stack) {
+      Log.critical("layrz_models/PushDevice/register(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+
+  /// [bindOperations] binds a list of operations to a push device.
+  /// Replaces all existing operation bindings. Pass an empty list to clear all bindings.
+  /// Returns true on success, false on failure.
+  static Future<bool> bindOperations({
+    /// [deviceId] is the ID of the push device to bind operations to.
+    required String deviceId,
+
+    /// [operationIds] is the list of operation IDs to bind (may be empty to clear bindings).
+    required List<String> operationIds,
+
+    /// [apiToken] is the API token to use for authentication.
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use.
+    required Uri uri,
+
+    /// [onResponse] is an optional callback invoked with the status code.
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.perform(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'deviceId', type: .id, isRequired: true, value: deviceId),
+            GqlVariable(
+              name: 'operationIds',
+              type: .list(of: .id, isRequired: false),
+              isRequired: false,
+              value: operationIds,
+            ),
+          ],
+          name: 'bindOperationsToPushDevice',
+        )..add(
+          GqlField(
+            name: 'bindOperationsToPushDevice',
+            args: {
+              'deviceId': 'deviceId',
+              'operationIds': 'operationIds',
+            },
+          )..add(GqlField(name: 'status')),
+        ),
+      );
+
+      final data = response.data;
+      if (data == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/PushDevice/bindOperations(): No response from server");
+        return false;
+      }
+
+      final result = data['data']['bindOperationsToPushDevice'];
+      if (result == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/PushDevice/bindOperations(): No result from server");
+        return false;
+      }
+
+      final status = ApiStatus.fromJson(result['status']);
+      onResponse?.call(status.toJson());
+
+      return status == ApiStatus.ok;
+    } catch (e, stack) {
+      Log.critical("layrz_models/PushDevice/bindOperations(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+
+  /// [deregister] deregisters a push device by its ID.
+  /// Returns true on success, false on failure.
+  static Future<bool> deregister({
+    /// [deviceId] is the ID of the push device to deregister.
+    required String deviceId,
+
+    /// [apiToken] is the API token to use for authentication.
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use.
+    required Uri uri,
+
+    /// [onResponse] is an optional callback invoked with the status code.
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.perform(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'deviceId', type: .id, isRequired: true, value: deviceId),
+          ],
+          name: 'deregisterPushDevice',
+        )..add(
+          GqlField(name: 'deregisterPushDevice', args: {'deviceId': 'deviceId'})..add(GqlField(name: 'status')),
+        ),
+      );
+
+      final data = response.data;
+      if (data == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/PushDevice/deregister(): No response from server");
+        return false;
+      }
+
+      final result = data['data']['deregisterPushDevice'];
+      if (result == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/PushDevice/deregister(): No result from server");
+        return false;
+      }
+
+      final status = ApiStatus.fromJson(result['status']);
+      onResponse?.call(status.toJson());
+
+      return status == ApiStatus.ok;
+    } catch (e, stack) {
+      Log.critical("layrz_models/PushDevice/deregister(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+}
+
+/// [PushDeviceValidation] is the response from [PushDevice.validate()].
+/// It carries the validated [PushDevice] and the list of operation IDs currently bound to it.
+class PushDeviceValidation {
+  /// [device] is the validated push device.
+  final PushDevice device;
+
+  /// [operationIds] is the list of operation IDs currently bound to this device.
+  final List<String> operationIds;
+
+  /// Creates a [PushDeviceValidation] response.
+  PushDeviceValidation({required this.device, required this.operationIds});
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.15.2"
+version: "3.16.0"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
## Summary

Introduces the new `PushDevice` model providing end-to-end GraphQL operations for push device management. This model powers the layrz_session push notifications tab with four core operations: validation, registration, operation binding, and deregistration. All API calls use the Gql builder with header-based authentication.

## Changes

- **New PushDevice Model**: Wraps push-device GraphQL operations
- **Operations**:
  - `validatePushDevice` - Validate device and retrieve bound operation IDs
  - `registerPushDevice` - Register a new push device
  - `bindOperationsToPushDevice` - Associate operations with the device
  - `deregisterPushDevice` - Deregister a push device

**Version**: 3.16.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)