### PR TITLE
Add GqlVariableType.enum_ factory and update RegisteredApp for type safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.18.1
+
+- New `GqlVariableType.enum_()` factory for GraphQL enum variables, allowing type-safe enum variable declarations in queries and mutations.
+- Corrected `RegisteredApp.load()` to fix the `platform` and `technology` fields to be their respective enums `AppPlatform` and `AppTechnology` instead of plain strings, ensuring proper type safety and deserialization.
+
 ## 3.18.0
 
 - Added API connector for `Geofence` with full GraphQL support (`fetch`, `fetchAll`, `save`, `delete`, `exportMany`).

--- a/lib/src/api/src/gql_builder/variables.dart
+++ b/lib/src/api/src/gql_builder/variables.dart
@@ -22,6 +22,8 @@ class GqlVariableType {
   }
 
   static GqlVariableType input({required String of}) => GqlVariableType._(of);
+
+  static GqlVariableType enum_({required String of}) => GqlVariableType._(of);
 }
 
 class GqlVariable {

--- a/lib/src/app/src/registered_app.dart
+++ b/lib/src/app/src/registered_app.dart
@@ -708,8 +708,18 @@ abstract class RegisteredApp with _$RegisteredApp {
         GqlQuery(
           variables: [
             GqlVariable(name: 'appId', type: .id, isRequired: true, value: appId),
-            GqlVariable(name: 'platform', type: .string, isRequired: true, value: platform.name),
-            GqlVariable(name: 'technology', type: .string, isRequired: true, value: technology.name),
+            GqlVariable(
+              name: 'platform',
+              type: .enum_(of: 'AppPlatform'),
+              isRequired: true,
+              value: platform.name,
+            ),
+            GqlVariable(
+              name: 'technology',
+              type: .enum_(of: 'AppTechnology'),
+              isRequired: true,
+              value: technology.name,
+            ),
           ],
         )..add(
           GqlField(name: 'loadApp', args: {'platform': 'platform', 'technology': 'technology', 'appId': 'appId'})

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.18.0"
+version: "3.18.1"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
Introduce a new `GqlVariableType.enum_()` factory for type-safe GraphQL enum variable declarations. Update `RegisteredApp.load()` to use enum types for `platform` and `technology`, enhancing type safety and deserialization. Update version to 3.18.1 in the changelog.