### PR TITLE
feat: add variant-aware API connectors for SDM, User and Reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 3.19.0
+
+- Added `SdmPenInput`, `SdmIngredientInput`, `SdmOperatorInput` and `SdmRecipeInput` unfreezed input models for the SDM entities.
+- Added `fragment` getters to `SdmPen`, `SdmIngredient`, `SdmOperator` and `SdmRecipe`.
+- Added API connectors for the SDM entities with `fetchAll`, `fetch`, `deleteMultiple` and `save` (on the input models).
+- Added bulk operations to `SdmPen`, `SdmIngredient` and `SdmRecipe`: `bulkLoad`, `export` and `formatExcel`, returning the generated `resultUri` where applicable.
+- Added `UserVariant` enum (`standard`, `ats`, `atsAdmin`, `brickhouse`, `sdm`, `tagon` and the `mappit*` variants) to drive user queries and mutations from a single source of truth.
+- Added variant-aware API connectors to `User`: `fetchAll`, `fetch`, `deleteMultiple` and `save` (on `UserInput`), resolving the query, mutation and input type names per variant, with optional `appId`, `languageId` and `mappitModule` arguments.
+- Added `User.fragment(variant:)` covering `access`, `referencesIds`, `categoryId`, `tagsIds` plus the variant-specific fields, and a `withDetails` option on `User.fetch` for the `tags`, `references`, `category` and `allowedApps` expansions.
+- Added account action connectors to `User`: `importIntoApp`, `resetPassword`, `setPaymentWarning`, `lock`, `suspend`, `invite` and `requestActivityReport`.
+- Migrated `User.fetchAll` and `User.fetchAllForAppUsers` to the typed `connector.query` API; `fetchAllForAppUsers` remains locked to the `standard` variant by design.
+- Added `ReferenceVariant` enum (`standard`, `mappit`, `sdm`) and `ReferenceInput` input model.
+- Added variant-aware API connectors to `Reference`: `fragment(variant:)`, `fetchAll`, `fetch`, `clone`, `deleteMultiple` and `save` (on `ReferenceInput`).
+- New `GqlVariableType.unix` for GraphQL `Unix` timestamp variables.
+- Added `ReferenceVariant` enum (`standard`, `mappit`, `sdm`) to drive reference queries and mutations from a single source of truth.
+- Added variant-aware API connectors to `Reference`: `fetchAll`, `fetch`, `deleteMultiple` and `save` (on `ReferenceInput`), resolving the query, mutation and input type names per variant — `references`/`mappitReferences`/`sdmReferences` for queries, and `add`/`edit`/`delete` mutations with the `Mappit` and `Sdm` infixes.
+- Added `Reference.fragment(variant:)` covering `id`, `name`, `category`, `customFields`, `qrCode` and `access`, reusing `CustomField.fragment` and `Access.idFragment`.
+- Added `Reference.clone`, which uses the `cloneReference` mutation for every variant.
+
 ## 3.18.2
 
 - Updated `Gql` to now auto-include name from the next field in the query or mutation if no name is provided, ensuring that all GraphQL operations have a valid name for better debugging and logging.

--- a/lib/src/api/src/gql_builder/variables.dart
+++ b/lib/src/api/src/gql_builder/variables.dart
@@ -12,6 +12,7 @@ class GqlVariableType {
   static const json = GqlVariableType._('Json');
   static const uuid = GqlVariableType._('Uuid');
   static const duration = GqlVariableType._('Duration');
+  static const unix = GqlVariableType._('Unix');
 
   static GqlVariableType list({required GqlVariableType of, bool isRequired = false}) {
     if (isRequired) {

--- a/lib/src/references/references.dart
+++ b/lib/src/references/references.dart
@@ -2,6 +2,7 @@ library;
 
 import 'package:collection/collection.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:layrz_logging/layrz_logging.dart';
 import 'package:layrz_models/layrz_models.dart';
 
 part 'references.freezed.dart';
@@ -9,3 +10,4 @@ part 'references.g.dart';
 
 part 'src/reference.dart';
 part 'src/category.dart';
+part 'src/variant.dart';

--- a/lib/src/references/src/reference.dart
+++ b/lib/src/references/src/reference.dart
@@ -1,5 +1,79 @@
 part of '../references.dart';
 
+List<Reference> _referenceListDecoder(Object? json) {
+  return List<Reference>.from(
+    (json as List).map((e) {
+      return Reference.fromJson(e as Map<String, dynamic>);
+    }),
+  );
+}
+
+Reference _referenceDecoder(Object? json) {
+  return Reference.fromJson(json as Map<String, dynamic>);
+}
+
+// coverage:ignore-start
+/// [_getGqlQueryName] returns the GraphQL query name based on the reference variant.
+String _getGqlQueryName({required ReferenceVariant variant}) {
+  switch (variant) {
+    case .standard:
+      return 'references';
+    case .mappit:
+      return 'mappitReferences';
+    case .sdm:
+      return 'sdmReferences';
+  }
+}
+
+/// [_getSaveMutationName] returns the GraphQL mutation name for saving a reference based on the variant and whether it's a new reference.
+String _getSaveMutationName({required ReferenceVariant variant, required bool isNew}) {
+  switch (variant) {
+    case .standard:
+      return isNew ? 'addReference' : 'editReference';
+    case .mappit:
+      return isNew ? 'addMappitReference' : 'editMappitReference';
+    case .sdm:
+      return isNew ? 'addSdmReference' : 'editSdmReference';
+  }
+}
+
+/// [_getDeleteMutationName] returns the GraphQL mutation name for deleting references based on the variant.
+String _getDeleteMutationName({required ReferenceVariant variant}) {
+  switch (variant) {
+    case .standard:
+      return 'deleteReferences';
+    case .mappit:
+      return 'deleteMappitReferences';
+    case .sdm:
+      return 'deleteSdmReferences';
+  }
+}
+
+/// [_getInputTypeName] returns the GraphQL input type name for reference input based on the variant.
+String _getInputTypeName({required ReferenceVariant variant}) {
+  switch (variant) {
+    case .standard:
+      return 'ReferenceInput';
+    case .mappit:
+      return 'MappitReferenceInput';
+    case .sdm:
+      return 'SdmReferenceInput';
+  }
+}
+
+/// [_getGqlEntityName] returns the GraphQL entity name based on the reference variant.
+String _getGqlEntityName({required ReferenceVariant variant}) {
+  switch (variant) {
+    case .standard:
+      return 'Reference';
+    case .mappit:
+      return 'MappitReference';
+    case .sdm:
+      return 'SdmReference';
+  }
+}
+// coverage:ignore-end
+
 @freezed
 abstract class Reference with _$Reference {
   const factory Reference({
@@ -25,6 +99,235 @@ abstract class Reference with _$Reference {
   }) = _Reference;
 
   factory Reference.fromJson(Map<String, dynamic> json) => _$ReferenceFromJson(json);
+
+  // coverage:ignore-start
+  /// [fragment] is the GqlFragment for a reference, with full parity across variants.
+  static GqlFragment fragment({ReferenceVariant variant = .standard}) {
+    final gql = GqlFragment(
+      name: 'referenceFragment',
+      onType: _getGqlEntityName(variant: variant),
+    );
+
+    gql.add(GqlField(name: 'id'));
+    gql.add(GqlField(name: 'name'));
+    gql.add(GqlField(name: 'category'));
+    gql.add(GqlField(name: 'customFields', fragment: CustomField.fragment));
+    gql.add(GqlField(name: 'qrCode'));
+    gql.add(GqlField(name: 'access', fragment: Access.idFragment));
+
+    return gql;
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fetchAll] fetches all references from the API with a lightweight payload.
+  static Future<List<Reference>> fetchAll({
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+    ReferenceVariant variant = .standard,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [],
+          name: _getGqlQueryName(variant: variant),
+        )..add(
+          GqlField(name: _getGqlQueryName(variant: variant))
+            ..add(GqlField(name: 'status'))
+            ..add(
+              GqlField(
+                name: 'result',
+                fields: [
+                  GqlField(name: 'id'),
+                  GqlField(name: 'name'),
+                  GqlField(name: 'category'),
+                ],
+              ),
+            ),
+        ),
+        _referenceListDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        Log.error("layrz_models/Reference/fetchAll(): No response from server");
+        return [];
+      }
+
+      final result = response.result;
+      if (result == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/Reference/fetchAll(): No result from server");
+        return [];
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return [];
+      }
+
+      return response.result ?? [];
+    } catch (e, stack) {
+      Log.critical("layrz_models/Reference/fetchAll(): General exception => $e\n$stack");
+      return [];
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fetch] fetches a single reference by ID.
+  /// Returns a [Reference] on success or null on error.
+  static Future<Reference?> fetch({
+    required String id,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+    ReferenceVariant variant = .standard,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [
+            GqlVariable(name: 'id', type: .id, isRequired: true, value: id),
+          ],
+          name: _getGqlQueryName(variant: variant),
+        )..add(
+          GqlField(
+            name: _getGqlQueryName(variant: variant),
+            args: {'id': 'id'},
+          )
+            ..add(GqlField(name: 'status'))
+            ..add(
+              GqlField(
+                name: 'result',
+                fragment: fragment(variant: variant),
+              ),
+            ),
+        ),
+        _referenceListDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        Log.error("layrz_models/Reference/fetch(): No response from server");
+        return null;
+      }
+
+      final result = response.result;
+      if (result == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/Reference/fetch(): No result from server");
+        return null;
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return null;
+      }
+
+      return result.isNotEmpty ? result.first : null;
+    } catch (e, stack) {
+      Log.critical("layrz_models/Reference/fetch(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [clone] clones a reference by ID.
+  /// Returns the cloned [Reference] on success or null on error.
+  static Future<Reference?> clone({
+    required String referenceId,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'referenceId', type: .id, isRequired: true, value: referenceId),
+          ],
+          name: 'cloneReference',
+        )..add(
+          GqlField(name: 'cloneReference', args: {'referenceId': 'referenceId'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(
+              GqlField(
+                name: 'result',
+                fragment: fragment(),
+              ),
+            ),
+        ),
+        _referenceDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        Log.error("layrz_models/Reference/clone(): No response from server");
+        return null;
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return null;
+      }
+
+      return response.result;
+    } catch (e, stack) {
+      Log.critical("layrz_models/Reference/clone(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [deleteMultiple] deletes multiple references by their IDs.
+  /// Returns true on success, false on error.
+  static Future<bool> deleteMultiple({
+    required List<String> ids,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+    ReferenceVariant variant = .standard,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(
+              name: 'ids',
+              type: .list(of: .id, isRequired: true),
+              isRequired: true,
+              value: ids,
+            ),
+          ],
+          name: _getDeleteMutationName(variant: variant),
+        )..add(
+          GqlField(
+            name: _getDeleteMutationName(variant: variant),
+            args: {'ids': 'ids'},
+          )..add(GqlField(name: 'status')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/Reference/deleteMultiple(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
 }
 
 @unfreezed
@@ -48,4 +351,67 @@ abstract class ReferenceInput with _$ReferenceInput {
   }) = _ReferenceInput;
 
   factory ReferenceInput.fromJson(Map<String, dynamic> json) => _$ReferenceInputFromJson(json);
+
+  // coverage:ignore-start
+  /// [save] saves a reference (add or edit) and returns a record with status, errors, and the saved reference.
+  /// Returns `(ApiStatus, Map<String, dynamic>?, Reference?)` — on internalError: (internalError, null, null);
+  /// on other error: (status, errors, null); on success: (status, errors, reference).
+  Future<(ApiStatus, Map<String, dynamic>?, Reference?)> save({
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+    ReferenceVariant variant = .standard,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final isNew = id == null;
+      final operation = _getSaveMutationName(variant: variant, isNew: isNew);
+
+      final payload = toJson();
+
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(
+              name: 'data',
+              type: GqlVariableType.input(of: _getInputTypeName(variant: variant)),
+              isRequired: true,
+              value: payload,
+            ),
+          ],
+          name: operation,
+        )..add(
+          GqlField(
+            name: operation,
+            args: {'data': 'data'},
+          )
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(
+              GqlField(
+                name: 'result',
+                fragment: Reference.fragment(variant: variant),
+              ),
+            ),
+        ),
+        _referenceDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        return (ApiStatus.internalError, null, null);
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors, null);
+      }
+
+      return (response.status, response.errors, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/Reference/save(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null, null);
+    }
+  }
+  // coverage:ignore-end
 }

--- a/lib/src/references/src/variant.dart
+++ b/lib/src/references/src/variant.dart
@@ -1,0 +1,12 @@
+part of '../references.dart';
+
+enum ReferenceVariant {
+  /// Defines the standard variant of a reference, used in most of the Layrz Apps.
+  standard,
+
+  /// Defines the variant used on Mappit ecosystem
+  mappit,
+
+  /// Defines the variant used on SDM ecosystem
+  sdm,
+}

--- a/lib/src/sdm/sdm.dart
+++ b/lib/src/sdm/sdm.dart
@@ -1,6 +1,7 @@
 library;
 
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:layrz_logging/layrz_logging.dart';
 
 import '../../layrz_models.dart';
 

--- a/lib/src/sdm/sdm.freezed.dart
+++ b/lib/src/sdm/sdm.freezed.dart
@@ -261,8 +261,8 @@ return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.source,_that
 /// @nodoc
 @JsonSerializable()
 
-class _SdmPen implements SdmPen {
-  const _SdmPen({required this.id, required this.name, required this.code, this.sourceId, this.source, @TimestampOrNullConverter() this.createdAt, this.createdBy, @TimestampOrNullConverter() this.updatedAt, this.updatedBy});
+class _SdmPen extends SdmPen {
+  const _SdmPen({required this.id, required this.name, required this.code, this.sourceId, this.source, @TimestampOrNullConverter() this.createdAt, this.createdBy, @TimestampOrNullConverter() this.updatedAt, this.updatedBy}): super._();
   factory _SdmPen.fromJson(Map<String, dynamic> json) => _$SdmPenFromJson(json);
 
 /// [id] of the pen entity. This ID is unique.
@@ -386,6 +386,282 @@ $UserCopyWith<$Res>? get updatedBy {
     return _then(_self.copyWith(updatedBy: value));
   });
 }
+}
+
+
+/// @nodoc
+mixin _$SdmPenInput {
+
+/// [id] of the pen entity. This ID is unique.
+ String? get id;/// [id] of the pen entity. This ID is unique.
+ set id(String? value);/// [name] of the pen.
+ String get name;/// [name] of the pen.
+ set name(String value);/// [code] of the pen.
+ String get code;/// [code] of the pen.
+ set code(String value);/// [sourceId] is the device id of the pen.
+ String? get sourceId;/// [sourceId] is the device id of the pen.
+ set sourceId(String? value);/// [pensHeadCountStimated] is the estimated count of pen heads.
+ int? get pensHeadCountStimated;/// [pensHeadCountStimated] is the estimated count of pen heads.
+ set pensHeadCountStimated(int? value);
+/// Create a copy of SdmPenInput
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SdmPenInputCopyWith<SdmPenInput> get copyWith => _$SdmPenInputCopyWithImpl<SdmPenInput>(this as SdmPenInput, _$identity);
+
+  /// Serializes this SdmPenInput to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+
+
+@override
+String toString() {
+  return 'SdmPenInput(id: $id, name: $name, code: $code, sourceId: $sourceId, pensHeadCountStimated: $pensHeadCountStimated)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SdmPenInputCopyWith<$Res>  {
+  factory $SdmPenInputCopyWith(SdmPenInput value, $Res Function(SdmPenInput) _then) = _$SdmPenInputCopyWithImpl;
+@useResult
+$Res call({
+ String? id, String name, String code, String? sourceId, int? pensHeadCountStimated
+});
+
+
+
+
+}
+/// @nodoc
+class _$SdmPenInputCopyWithImpl<$Res>
+    implements $SdmPenInputCopyWith<$Res> {
+  _$SdmPenInputCopyWithImpl(this._self, this._then);
+
+  final SdmPenInput _self;
+  final $Res Function(SdmPenInput) _then;
+
+/// Create a copy of SdmPenInput
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? name = null,Object? code = null,Object? sourceId = freezed,Object? pensHeadCountStimated = freezed,}) {
+  return _then(_self.copyWith(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,sourceId: freezed == sourceId ? _self.sourceId : sourceId // ignore: cast_nullable_to_non_nullable
+as String?,pensHeadCountStimated: freezed == pensHeadCountStimated ? _self.pensHeadCountStimated : pensHeadCountStimated // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SdmPenInput].
+extension SdmPenInputPatterns on SdmPenInput {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SdmPenInput value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SdmPenInput() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SdmPenInput value)  $default,){
+final _that = this;
+switch (_that) {
+case _SdmPenInput():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SdmPenInput value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SdmPenInput() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  String name,  String code,  String? sourceId,  int? pensHeadCountStimated)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SdmPenInput() when $default != null:
+return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.pensHeadCountStimated);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  String name,  String code,  String? sourceId,  int? pensHeadCountStimated)  $default,) {final _that = this;
+switch (_that) {
+case _SdmPenInput():
+return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.pensHeadCountStimated);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  String name,  String code,  String? sourceId,  int? pensHeadCountStimated)?  $default,) {final _that = this;
+switch (_that) {
+case _SdmPenInput() when $default != null:
+return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.pensHeadCountStimated);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SdmPenInput extends SdmPenInput {
+   _SdmPenInput({this.id, this.name = '', this.code = '', this.sourceId, this.pensHeadCountStimated}): super._();
+  factory _SdmPenInput.fromJson(Map<String, dynamic> json) => _$SdmPenInputFromJson(json);
+
+/// [id] of the pen entity. This ID is unique.
+@override  String? id;
+/// [name] of the pen.
+@override@JsonKey()  String name;
+/// [code] of the pen.
+@override@JsonKey()  String code;
+/// [sourceId] is the device id of the pen.
+@override  String? sourceId;
+/// [pensHeadCountStimated] is the estimated count of pen heads.
+@override  int? pensHeadCountStimated;
+
+/// Create a copy of SdmPenInput
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SdmPenInputCopyWith<_SdmPenInput> get copyWith => __$SdmPenInputCopyWithImpl<_SdmPenInput>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SdmPenInputToJson(this, );
+}
+
+
+
+@override
+String toString() {
+  return 'SdmPenInput(id: $id, name: $name, code: $code, sourceId: $sourceId, pensHeadCountStimated: $pensHeadCountStimated)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SdmPenInputCopyWith<$Res> implements $SdmPenInputCopyWith<$Res> {
+  factory _$SdmPenInputCopyWith(_SdmPenInput value, $Res Function(_SdmPenInput) _then) = __$SdmPenInputCopyWithImpl;
+@override @useResult
+$Res call({
+ String? id, String name, String code, String? sourceId, int? pensHeadCountStimated
+});
+
+
+
+
+}
+/// @nodoc
+class __$SdmPenInputCopyWithImpl<$Res>
+    implements _$SdmPenInputCopyWith<$Res> {
+  __$SdmPenInputCopyWithImpl(this._self, this._then);
+
+  final _SdmPenInput _self;
+  final $Res Function(_SdmPenInput) _then;
+
+/// Create a copy of SdmPenInput
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? name = null,Object? code = null,Object? sourceId = freezed,Object? pensHeadCountStimated = freezed,}) {
+  return _then(_SdmPenInput(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,sourceId: freezed == sourceId ? _self.sourceId : sourceId // ignore: cast_nullable_to_non_nullable
+as String?,pensHeadCountStimated: freezed == pensHeadCountStimated ? _self.pensHeadCountStimated : pensHeadCountStimated // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+
 }
 
 
@@ -642,8 +918,8 @@ return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.source,_that
 /// @nodoc
 @JsonSerializable()
 
-class _SdmRecipe implements SdmRecipe {
-  const _SdmRecipe({required this.id, required this.name, required this.code, this.sourceId, this.source, @TimestampOrNullConverter() this.createdAt, this.createdBy, @TimestampOrNullConverter() this.updatedAt, this.updatedBy, final  List<SdmIngredient>? ingredients, final  List<String>? ingredientsIds}): _ingredients = ingredients,_ingredientsIds = ingredientsIds;
+class _SdmRecipe extends SdmRecipe {
+  const _SdmRecipe({required this.id, required this.name, required this.code, this.sourceId, this.source, @TimestampOrNullConverter() this.createdAt, this.createdBy, @TimestampOrNullConverter() this.updatedAt, this.updatedBy, final  List<SdmIngredient>? ingredients, final  List<String>? ingredientsIds}): _ingredients = ingredients,_ingredientsIds = ingredientsIds,super._();
   factory _SdmRecipe.fromJson(Map<String, dynamic> json) => _$SdmRecipeFromJson(json);
 
 /// [id] of the pen entity. This ID is unique.
@@ -791,6 +1067,282 @@ $UserCopyWith<$Res>? get updatedBy {
     return _then(_self.copyWith(updatedBy: value));
   });
 }
+}
+
+
+/// @nodoc
+mixin _$SdmRecipeInput {
+
+/// [id] of the recipe entity. This ID is unique.
+ String? get id;/// [id] of the recipe entity. This ID is unique.
+ set id(String? value);/// [name] of the recipe.
+ String get name;/// [name] of the recipe.
+ set name(String value);/// [code] of the recipe.
+ String get code;/// [code] of the recipe.
+ set code(String value);/// [sourceId] is the device id of the recipe.
+ String? get sourceId;/// [sourceId] is the device id of the recipe.
+ set sourceId(String? value);/// [ingredientsIds] is the list of ingredients ids of the recipe.
+ List<String> get ingredientsIds;/// [ingredientsIds] is the list of ingredients ids of the recipe.
+ set ingredientsIds(List<String> value);
+/// Create a copy of SdmRecipeInput
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SdmRecipeInputCopyWith<SdmRecipeInput> get copyWith => _$SdmRecipeInputCopyWithImpl<SdmRecipeInput>(this as SdmRecipeInput, _$identity);
+
+  /// Serializes this SdmRecipeInput to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+
+
+@override
+String toString() {
+  return 'SdmRecipeInput(id: $id, name: $name, code: $code, sourceId: $sourceId, ingredientsIds: $ingredientsIds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SdmRecipeInputCopyWith<$Res>  {
+  factory $SdmRecipeInputCopyWith(SdmRecipeInput value, $Res Function(SdmRecipeInput) _then) = _$SdmRecipeInputCopyWithImpl;
+@useResult
+$Res call({
+ String? id, String name, String code, String? sourceId, List<String> ingredientsIds
+});
+
+
+
+
+}
+/// @nodoc
+class _$SdmRecipeInputCopyWithImpl<$Res>
+    implements $SdmRecipeInputCopyWith<$Res> {
+  _$SdmRecipeInputCopyWithImpl(this._self, this._then);
+
+  final SdmRecipeInput _self;
+  final $Res Function(SdmRecipeInput) _then;
+
+/// Create a copy of SdmRecipeInput
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? name = null,Object? code = null,Object? sourceId = freezed,Object? ingredientsIds = null,}) {
+  return _then(_self.copyWith(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,sourceId: freezed == sourceId ? _self.sourceId : sourceId // ignore: cast_nullable_to_non_nullable
+as String?,ingredientsIds: null == ingredientsIds ? _self.ingredientsIds : ingredientsIds // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SdmRecipeInput].
+extension SdmRecipeInputPatterns on SdmRecipeInput {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SdmRecipeInput value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SdmRecipeInput() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SdmRecipeInput value)  $default,){
+final _that = this;
+switch (_that) {
+case _SdmRecipeInput():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SdmRecipeInput value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SdmRecipeInput() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  String name,  String code,  String? sourceId,  List<String> ingredientsIds)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SdmRecipeInput() when $default != null:
+return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.ingredientsIds);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  String name,  String code,  String? sourceId,  List<String> ingredientsIds)  $default,) {final _that = this;
+switch (_that) {
+case _SdmRecipeInput():
+return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.ingredientsIds);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  String name,  String code,  String? sourceId,  List<String> ingredientsIds)?  $default,) {final _that = this;
+switch (_that) {
+case _SdmRecipeInput() when $default != null:
+return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.ingredientsIds);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SdmRecipeInput extends SdmRecipeInput {
+   _SdmRecipeInput({this.id, this.name = '', this.code = '', this.sourceId, this.ingredientsIds = const []}): super._();
+  factory _SdmRecipeInput.fromJson(Map<String, dynamic> json) => _$SdmRecipeInputFromJson(json);
+
+/// [id] of the recipe entity. This ID is unique.
+@override  String? id;
+/// [name] of the recipe.
+@override@JsonKey()  String name;
+/// [code] of the recipe.
+@override@JsonKey()  String code;
+/// [sourceId] is the device id of the recipe.
+@override  String? sourceId;
+/// [ingredientsIds] is the list of ingredients ids of the recipe.
+@override@JsonKey()  List<String> ingredientsIds;
+
+/// Create a copy of SdmRecipeInput
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SdmRecipeInputCopyWith<_SdmRecipeInput> get copyWith => __$SdmRecipeInputCopyWithImpl<_SdmRecipeInput>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SdmRecipeInputToJson(this, );
+}
+
+
+
+@override
+String toString() {
+  return 'SdmRecipeInput(id: $id, name: $name, code: $code, sourceId: $sourceId, ingredientsIds: $ingredientsIds)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SdmRecipeInputCopyWith<$Res> implements $SdmRecipeInputCopyWith<$Res> {
+  factory _$SdmRecipeInputCopyWith(_SdmRecipeInput value, $Res Function(_SdmRecipeInput) _then) = __$SdmRecipeInputCopyWithImpl;
+@override @useResult
+$Res call({
+ String? id, String name, String code, String? sourceId, List<String> ingredientsIds
+});
+
+
+
+
+}
+/// @nodoc
+class __$SdmRecipeInputCopyWithImpl<$Res>
+    implements _$SdmRecipeInputCopyWith<$Res> {
+  __$SdmRecipeInputCopyWithImpl(this._self, this._then);
+
+  final _SdmRecipeInput _self;
+  final $Res Function(_SdmRecipeInput) _then;
+
+/// Create a copy of SdmRecipeInput
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? name = null,Object? code = null,Object? sourceId = freezed,Object? ingredientsIds = null,}) {
+  return _then(_SdmRecipeInput(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,sourceId: freezed == sourceId ? _self.sourceId : sourceId // ignore: cast_nullable_to_non_nullable
+as String?,ingredientsIds: null == ingredientsIds ? _self.ingredientsIds : ingredientsIds // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+
 }
 
 
@@ -1051,8 +1603,8 @@ return $default(_that.id,_that.name,_that.code,_that.pricePerKg,_that.dryFactor,
 /// @nodoc
 @JsonSerializable()
 
-class _SdmIngredient implements SdmIngredient {
-  const _SdmIngredient({required this.id, required this.name, required this.code, this.pricePerKg, this.dryFactor, this.priceByDry, this.isArchived, this.sourceId, this.source, @TimestampOrNullConverter() this.createdAt, this.createdBy, @TimestampOrNullConverter() this.updatedAt, this.updatedBy});
+class _SdmIngredient extends SdmIngredient {
+  const _SdmIngredient({required this.id, required this.name, required this.code, this.pricePerKg, this.dryFactor, this.priceByDry, this.isArchived, this.sourceId, this.source, @TimestampOrNullConverter() this.createdAt, this.createdBy, @TimestampOrNullConverter() this.updatedAt, this.updatedBy}): super._();
   factory _SdmIngredient.fromJson(Map<String, dynamic> json) => _$SdmIngredientFromJson(json);
 
 /// [id] of the pen entity. This ID is unique.
@@ -1188,6 +1740,300 @@ $UserCopyWith<$Res>? get updatedBy {
     return _then(_self.copyWith(updatedBy: value));
   });
 }
+}
+
+
+/// @nodoc
+mixin _$SdmIngredientInput {
+
+/// [id] of the ingredient entity. This ID is unique.
+ String? get id;/// [id] of the ingredient entity. This ID is unique.
+ set id(String? value);/// [name] of the ingredient.
+ String get name;/// [name] of the ingredient.
+ set name(String value);/// [code] of the ingredient.
+ String get code;/// [code] of the ingredient.
+ set code(String value);/// [sourceId] is the device id of the ingredient.
+ String? get sourceId;/// [sourceId] is the device id of the ingredient.
+ set sourceId(String? value);/// [pricePerKg] is the price of the ingredient per kilogram.
+ double get pricePerKg;/// [pricePerKg] is the price of the ingredient per kilogram.
+ set pricePerKg(double value);/// [dryFactor] is the dry factor of the ingredient.
+ double get dryFactor;/// [dryFactor] is the dry factor of the ingredient.
+ set dryFactor(double value);/// [priceByDry] indicates if the price should be calculated using dry or wet weight.
+ bool get priceByDry;/// [priceByDry] indicates if the price should be calculated using dry or wet weight.
+ set priceByDry(bool value);/// [isArchived] is the status of the ingredient.
+ bool get isArchived;/// [isArchived] is the status of the ingredient.
+ set isArchived(bool value);
+/// Create a copy of SdmIngredientInput
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SdmIngredientInputCopyWith<SdmIngredientInput> get copyWith => _$SdmIngredientInputCopyWithImpl<SdmIngredientInput>(this as SdmIngredientInput, _$identity);
+
+  /// Serializes this SdmIngredientInput to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+
+
+@override
+String toString() {
+  return 'SdmIngredientInput(id: $id, name: $name, code: $code, sourceId: $sourceId, pricePerKg: $pricePerKg, dryFactor: $dryFactor, priceByDry: $priceByDry, isArchived: $isArchived)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SdmIngredientInputCopyWith<$Res>  {
+  factory $SdmIngredientInputCopyWith(SdmIngredientInput value, $Res Function(SdmIngredientInput) _then) = _$SdmIngredientInputCopyWithImpl;
+@useResult
+$Res call({
+ String? id, String name, String code, String? sourceId, double pricePerKg, double dryFactor, bool priceByDry, bool isArchived
+});
+
+
+
+
+}
+/// @nodoc
+class _$SdmIngredientInputCopyWithImpl<$Res>
+    implements $SdmIngredientInputCopyWith<$Res> {
+  _$SdmIngredientInputCopyWithImpl(this._self, this._then);
+
+  final SdmIngredientInput _self;
+  final $Res Function(SdmIngredientInput) _then;
+
+/// Create a copy of SdmIngredientInput
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? name = null,Object? code = null,Object? sourceId = freezed,Object? pricePerKg = null,Object? dryFactor = null,Object? priceByDry = null,Object? isArchived = null,}) {
+  return _then(_self.copyWith(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,sourceId: freezed == sourceId ? _self.sourceId : sourceId // ignore: cast_nullable_to_non_nullable
+as String?,pricePerKg: null == pricePerKg ? _self.pricePerKg : pricePerKg // ignore: cast_nullable_to_non_nullable
+as double,dryFactor: null == dryFactor ? _self.dryFactor : dryFactor // ignore: cast_nullable_to_non_nullable
+as double,priceByDry: null == priceByDry ? _self.priceByDry : priceByDry // ignore: cast_nullable_to_non_nullable
+as bool,isArchived: null == isArchived ? _self.isArchived : isArchived // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SdmIngredientInput].
+extension SdmIngredientInputPatterns on SdmIngredientInput {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SdmIngredientInput value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SdmIngredientInput() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SdmIngredientInput value)  $default,){
+final _that = this;
+switch (_that) {
+case _SdmIngredientInput():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SdmIngredientInput value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SdmIngredientInput() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  String name,  String code,  String? sourceId,  double pricePerKg,  double dryFactor,  bool priceByDry,  bool isArchived)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SdmIngredientInput() when $default != null:
+return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.pricePerKg,_that.dryFactor,_that.priceByDry,_that.isArchived);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  String name,  String code,  String? sourceId,  double pricePerKg,  double dryFactor,  bool priceByDry,  bool isArchived)  $default,) {final _that = this;
+switch (_that) {
+case _SdmIngredientInput():
+return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.pricePerKg,_that.dryFactor,_that.priceByDry,_that.isArchived);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  String name,  String code,  String? sourceId,  double pricePerKg,  double dryFactor,  bool priceByDry,  bool isArchived)?  $default,) {final _that = this;
+switch (_that) {
+case _SdmIngredientInput() when $default != null:
+return $default(_that.id,_that.name,_that.code,_that.sourceId,_that.pricePerKg,_that.dryFactor,_that.priceByDry,_that.isArchived);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SdmIngredientInput extends SdmIngredientInput {
+   _SdmIngredientInput({this.id, this.name = '', this.code = '', this.sourceId, this.pricePerKg = 0.0, this.dryFactor = 1.0, this.priceByDry = false, this.isArchived = false}): super._();
+  factory _SdmIngredientInput.fromJson(Map<String, dynamic> json) => _$SdmIngredientInputFromJson(json);
+
+/// [id] of the ingredient entity. This ID is unique.
+@override  String? id;
+/// [name] of the ingredient.
+@override@JsonKey()  String name;
+/// [code] of the ingredient.
+@override@JsonKey()  String code;
+/// [sourceId] is the device id of the ingredient.
+@override  String? sourceId;
+/// [pricePerKg] is the price of the ingredient per kilogram.
+@override@JsonKey()  double pricePerKg;
+/// [dryFactor] is the dry factor of the ingredient.
+@override@JsonKey()  double dryFactor;
+/// [priceByDry] indicates if the price should be calculated using dry or wet weight.
+@override@JsonKey()  bool priceByDry;
+/// [isArchived] is the status of the ingredient.
+@override@JsonKey()  bool isArchived;
+
+/// Create a copy of SdmIngredientInput
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SdmIngredientInputCopyWith<_SdmIngredientInput> get copyWith => __$SdmIngredientInputCopyWithImpl<_SdmIngredientInput>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SdmIngredientInputToJson(this, );
+}
+
+
+
+@override
+String toString() {
+  return 'SdmIngredientInput(id: $id, name: $name, code: $code, sourceId: $sourceId, pricePerKg: $pricePerKg, dryFactor: $dryFactor, priceByDry: $priceByDry, isArchived: $isArchived)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SdmIngredientInputCopyWith<$Res> implements $SdmIngredientInputCopyWith<$Res> {
+  factory _$SdmIngredientInputCopyWith(_SdmIngredientInput value, $Res Function(_SdmIngredientInput) _then) = __$SdmIngredientInputCopyWithImpl;
+@override @useResult
+$Res call({
+ String? id, String name, String code, String? sourceId, double pricePerKg, double dryFactor, bool priceByDry, bool isArchived
+});
+
+
+
+
+}
+/// @nodoc
+class __$SdmIngredientInputCopyWithImpl<$Res>
+    implements _$SdmIngredientInputCopyWith<$Res> {
+  __$SdmIngredientInputCopyWithImpl(this._self, this._then);
+
+  final _SdmIngredientInput _self;
+  final $Res Function(_SdmIngredientInput) _then;
+
+/// Create a copy of SdmIngredientInput
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? name = null,Object? code = null,Object? sourceId = freezed,Object? pricePerKg = null,Object? dryFactor = null,Object? priceByDry = null,Object? isArchived = null,}) {
+  return _then(_SdmIngredientInput(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,sourceId: freezed == sourceId ? _self.sourceId : sourceId // ignore: cast_nullable_to_non_nullable
+as String?,pricePerKg: null == pricePerKg ? _self.pricePerKg : pricePerKg // ignore: cast_nullable_to_non_nullable
+as double,dryFactor: null == dryFactor ? _self.dryFactor : dryFactor // ignore: cast_nullable_to_non_nullable
+as double,priceByDry: null == priceByDry ? _self.priceByDry : priceByDry // ignore: cast_nullable_to_non_nullable
+as bool,isArchived: null == isArchived ? _self.isArchived : isArchived // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
 }
 
 
@@ -1424,8 +2270,8 @@ return $default(_that.id,_that.name,_that.code,_that.createdAt,_that.createdBy,_
 /// @nodoc
 @JsonSerializable()
 
-class _SdmOperator implements SdmOperator {
-  const _SdmOperator({required this.id, required this.name, required this.code, @TimestampOrNullConverter() this.createdAt, this.createdBy, @TimestampOrNullConverter() this.updatedAt, this.updatedBy});
+class _SdmOperator extends SdmOperator {
+  const _SdmOperator({required this.id, required this.name, required this.code, @TimestampOrNullConverter() this.createdAt, this.createdBy, @TimestampOrNullConverter() this.updatedAt, this.updatedBy}): super._();
   factory _SdmOperator.fromJson(Map<String, dynamic> json) => _$SdmOperatorFromJson(json);
 
 /// [id] of the pen entity. This ID is unique.
@@ -1531,6 +2377,270 @@ $UserCopyWith<$Res>? get updatedBy {
     return _then(_self.copyWith(updatedBy: value));
   });
 }
+}
+
+
+/// @nodoc
+mixin _$SdmOperatorInput {
+
+/// [id] of the operator entity. This ID is unique.
+ String? get id;/// [id] of the operator entity. This ID is unique.
+ set id(String? value);/// [name] of the operator.
+ String get name;/// [name] of the operator.
+ set name(String value);/// [code] of the operator.
+ String get code;/// [code] of the operator.
+ set code(String value);
+/// Create a copy of SdmOperatorInput
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SdmOperatorInputCopyWith<SdmOperatorInput> get copyWith => _$SdmOperatorInputCopyWithImpl<SdmOperatorInput>(this as SdmOperatorInput, _$identity);
+
+  /// Serializes this SdmOperatorInput to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+
+
+@override
+String toString() {
+  return 'SdmOperatorInput(id: $id, name: $name, code: $code)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SdmOperatorInputCopyWith<$Res>  {
+  factory $SdmOperatorInputCopyWith(SdmOperatorInput value, $Res Function(SdmOperatorInput) _then) = _$SdmOperatorInputCopyWithImpl;
+@useResult
+$Res call({
+ String? id, String name, String code
+});
+
+
+
+
+}
+/// @nodoc
+class _$SdmOperatorInputCopyWithImpl<$Res>
+    implements $SdmOperatorInputCopyWith<$Res> {
+  _$SdmOperatorInputCopyWithImpl(this._self, this._then);
+
+  final SdmOperatorInput _self;
+  final $Res Function(SdmOperatorInput) _then;
+
+/// Create a copy of SdmOperatorInput
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? name = null,Object? code = null,}) {
+  return _then(_self.copyWith(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SdmOperatorInput].
+extension SdmOperatorInputPatterns on SdmOperatorInput {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SdmOperatorInput value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SdmOperatorInput() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SdmOperatorInput value)  $default,){
+final _that = this;
+switch (_that) {
+case _SdmOperatorInput():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SdmOperatorInput value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SdmOperatorInput() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String? id,  String name,  String code)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SdmOperatorInput() when $default != null:
+return $default(_that.id,_that.name,_that.code);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String? id,  String name,  String code)  $default,) {final _that = this;
+switch (_that) {
+case _SdmOperatorInput():
+return $default(_that.id,_that.name,_that.code);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String? id,  String name,  String code)?  $default,) {final _that = this;
+switch (_that) {
+case _SdmOperatorInput() when $default != null:
+return $default(_that.id,_that.name,_that.code);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _SdmOperatorInput extends SdmOperatorInput {
+   _SdmOperatorInput({this.id, this.name = '', this.code = ''}): super._();
+  factory _SdmOperatorInput.fromJson(Map<String, dynamic> json) => _$SdmOperatorInputFromJson(json);
+
+/// [id] of the operator entity. This ID is unique.
+@override  String? id;
+/// [name] of the operator.
+@override@JsonKey()  String name;
+/// [code] of the operator.
+@override@JsonKey()  String code;
+
+/// Create a copy of SdmOperatorInput
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SdmOperatorInputCopyWith<_SdmOperatorInput> get copyWith => __$SdmOperatorInputCopyWithImpl<_SdmOperatorInput>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SdmOperatorInputToJson(this, );
+}
+
+
+
+@override
+String toString() {
+  return 'SdmOperatorInput(id: $id, name: $name, code: $code)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SdmOperatorInputCopyWith<$Res> implements $SdmOperatorInputCopyWith<$Res> {
+  factory _$SdmOperatorInputCopyWith(_SdmOperatorInput value, $Res Function(_SdmOperatorInput) _then) = __$SdmOperatorInputCopyWithImpl;
+@override @useResult
+$Res call({
+ String? id, String name, String code
+});
+
+
+
+
+}
+/// @nodoc
+class __$SdmOperatorInputCopyWithImpl<$Res>
+    implements _$SdmOperatorInputCopyWith<$Res> {
+  __$SdmOperatorInputCopyWithImpl(this._self, this._then);
+
+  final _SdmOperatorInput _self;
+  final $Res Function(_SdmOperatorInput) _then;
+
+/// Create a copy of SdmOperatorInput
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? name = null,Object? code = null,}) {
+  return _then(_SdmOperatorInput(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,code: null == code ? _self.code : code // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/lib/src/sdm/sdm.g.dart
+++ b/lib/src/sdm/sdm.g.dart
@@ -40,6 +40,23 @@ Map<String, dynamic> _$SdmPenToJson(_SdmPen instance) => <String, dynamic>{
   'updatedBy': instance.updatedBy?.toJson(),
 };
 
+_SdmPenInput _$SdmPenInputFromJson(Map<String, dynamic> json) => _SdmPenInput(
+  id: json['id'] as String?,
+  name: json['name'] as String? ?? '',
+  code: json['code'] as String? ?? '',
+  sourceId: json['sourceId'] as String?,
+  pensHeadCountStimated: (json['pensHeadCountStimated'] as num?)?.toInt(),
+);
+
+Map<String, dynamic> _$SdmPenInputToJson(_SdmPenInput instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'code': instance.code,
+      'sourceId': instance.sourceId,
+      'pensHeadCountStimated': instance.pensHeadCountStimated,
+    };
+
 _SdmRecipe _$SdmRecipeFromJson(Map<String, dynamic> json) => _SdmRecipe(
   id: json['id'] as String,
   name: json['name'] as String,
@@ -80,6 +97,28 @@ Map<String, dynamic> _$SdmRecipeToJson(_SdmRecipe instance) =>
       'updatedAt': const TimestampOrNullConverter().toJson(instance.updatedAt),
       'updatedBy': instance.updatedBy?.toJson(),
       'ingredients': instance.ingredients?.map((e) => e.toJson()).toList(),
+      'ingredientsIds': instance.ingredientsIds,
+    };
+
+_SdmRecipeInput _$SdmRecipeInputFromJson(Map<String, dynamic> json) =>
+    _SdmRecipeInput(
+      id: json['id'] as String?,
+      name: json['name'] as String? ?? '',
+      code: json['code'] as String? ?? '',
+      sourceId: json['sourceId'] as String?,
+      ingredientsIds:
+          (json['ingredientsIds'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+    );
+
+Map<String, dynamic> _$SdmRecipeInputToJson(_SdmRecipeInput instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'code': instance.code,
+      'sourceId': instance.sourceId,
       'ingredientsIds': instance.ingredientsIds,
     };
 
@@ -127,6 +166,30 @@ Map<String, dynamic> _$SdmIngredientToJson(_SdmIngredient instance) =>
       'updatedBy': instance.updatedBy?.toJson(),
     };
 
+_SdmIngredientInput _$SdmIngredientInputFromJson(Map<String, dynamic> json) =>
+    _SdmIngredientInput(
+      id: json['id'] as String?,
+      name: json['name'] as String? ?? '',
+      code: json['code'] as String? ?? '',
+      sourceId: json['sourceId'] as String?,
+      pricePerKg: (json['pricePerKg'] as num?)?.toDouble() ?? 0.0,
+      dryFactor: (json['dryFactor'] as num?)?.toDouble() ?? 1.0,
+      priceByDry: json['priceByDry'] as bool? ?? false,
+      isArchived: json['isArchived'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$SdmIngredientInputToJson(_SdmIngredientInput instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'code': instance.code,
+      'sourceId': instance.sourceId,
+      'pricePerKg': instance.pricePerKg,
+      'dryFactor': instance.dryFactor,
+      'priceByDry': instance.priceByDry,
+      'isArchived': instance.isArchived,
+    };
+
 _SdmOperator _$SdmOperatorFromJson(Map<String, dynamic> json) => _SdmOperator(
   id: json['id'] as String,
   name: json['name'] as String,
@@ -154,4 +217,18 @@ Map<String, dynamic> _$SdmOperatorToJson(_SdmOperator instance) =>
       'createdBy': instance.createdBy?.toJson(),
       'updatedAt': const TimestampOrNullConverter().toJson(instance.updatedAt),
       'updatedBy': instance.updatedBy?.toJson(),
+    };
+
+_SdmOperatorInput _$SdmOperatorInputFromJson(Map<String, dynamic> json) =>
+    _SdmOperatorInput(
+      id: json['id'] as String?,
+      name: json['name'] as String? ?? '',
+      code: json['code'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$SdmOperatorInputToJson(_SdmOperatorInput instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'code': instance.code,
     };

--- a/lib/src/sdm/src/ingredient.dart
+++ b/lib/src/sdm/src/ingredient.dart
@@ -1,7 +1,23 @@
 part of '../sdm.dart';
 
+SdmIngredient _sdmIngredientDecoder(Object? json) {
+  return SdmIngredient.fromJson(json as Map<String, dynamic>);
+}
+
+List<SdmIngredient> _sdmIngredientListDecoder(Object? json) {
+  return List<SdmIngredient>.from(
+    (json as List? ?? []).map((e) => SdmIngredient.fromJson(Map<String, dynamic>.from(e as Map))),
+  );
+}
+
+String? _sdmIngredientResultUriDecoder(Object? json) {
+  return json as String?;
+}
+
 @freezed
 abstract class SdmIngredient with _$SdmIngredient {
+  const SdmIngredient._();
+
   const factory SdmIngredient({
     /// [id] of the pen entity. This ID is unique.
     required String id,
@@ -44,4 +60,379 @@ abstract class SdmIngredient with _$SdmIngredient {
   }) = _SdmIngredient;
 
   factory SdmIngredient.fromJson(Map<String, dynamic> json) => _$SdmIngredientFromJson(json);
+
+  // coverage:ignore-start
+  /// [fetchAll] fetches all SDM ingredients from the server
+  static Future<List<SdmIngredient>> fetchAll({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(variables: [])..add(
+          GqlField(name: 'sdmIngredients', args: {})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _sdmIngredientListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return [];
+      }
+
+      return response.result ?? [];
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmIngredient/fetchAll(): General exception => $e\n$stack");
+      return [];
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fetch] fetches a single SDM ingredient by ID from the server
+  static Future<SdmIngredient?> fetch({
+    /// [id] is the ID of the SDM ingredient to fetch
+    required String id,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [
+            GqlVariable(name: 'id', type: .id, isRequired: true, value: id),
+          ],
+        )..add(
+          GqlField(name: 'sdmIngredients', args: {'id': 'id'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _sdmIngredientListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return null;
+      }
+
+      final resultList = response.result;
+      if (resultList == null || resultList.isEmpty) {
+        Log.warning("layrz_models/SdmIngredient/fetch(): No result in list");
+        return null;
+      }
+      return resultList.first;
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmIngredient/fetch(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [deleteMultiple] deletes multiple SDM ingredients by ID from the server
+  static Future<bool> deleteMultiple({
+    /// [ids] are the IDs of the SDM ingredients to delete
+    required List<String> ids,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'ids', type: GqlVariableType.list(of: .id), isRequired: true, value: ids),
+          ],
+          name: 'deleteSdmIngredients',
+        )..add(
+          GqlField(name: 'deleteSdmIngredients', args: {'ids': 'ids'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmIngredient/deleteMultiple(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [bulkLoad] loads SDM ingredients from a base64-encoded file
+  static Future<(ApiStatus, Map<String, dynamic>?)> bulkLoad({
+    /// [file] is the base64-encoded file content
+    required String file,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'file', type: .string, isRequired: true, value: file),
+          ],
+          name: 'bulkLoadSdmIngredients',
+        )..add(
+          GqlField(name: 'bulkLoadSdmIngredients', args: {'file': 'file'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors);
+      }
+
+      return (response.status, response.errors);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmIngredient/bulkLoad(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [export] exports SDM ingredients to a downloadable file
+  static Future<(ApiStatus, String?)> export({
+    /// [languageId] is the language ID for the export
+    required String languageId,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'languageId', type: .id, isRequired: true, value: languageId),
+          ],
+          name: 'exportSdmIngredients',
+        )..add(
+          GqlField(name: 'exportSdmIngredients', args: {'languageId': 'languageId'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'resultUri', alias: 'result')),
+        ),
+        _sdmIngredientResultUriDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, null);
+      }
+
+      return (response.status, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmIngredient/export(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [formatExcel] formats and downloads an SDM ingredients Excel template
+  static Future<(ApiStatus, String?)> formatExcel({
+    /// [languageId] is the language ID for the template
+    required String languageId,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'languageId', type: .id, isRequired: true, value: languageId),
+          ],
+          name: 'sdmIngredientsFormatExcel',
+        )..add(
+          GqlField(name: 'sdmIngredientsFormatExcel', args: {'languageId': 'languageId'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'resultUri', alias: 'result')),
+        ),
+        _sdmIngredientResultUriDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, null);
+      }
+
+      return (response.status, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmIngredient/formatExcel(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fragment] is the GqlFragment for an SDM ingredient
+  static GqlFragment get fragment => GqlFragment(name: 'sdmIngredientFragment', onType: 'SdmIngredient')
+    ..add(GqlField(name: 'id'))
+    ..add(GqlField(name: 'name'))
+    ..add(GqlField(name: 'code'))
+    ..add(GqlField(name: 'sourceId'))
+    ..add(
+      GqlField(name: 'source')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'ident')),
+    )
+    ..add(GqlField(name: 'pricePerKg'))
+    ..add(GqlField(name: 'dryFactor'))
+    ..add(GqlField(name: 'priceByDry'))
+    ..add(GqlField(name: 'isArchived'))
+    ..add(GqlField(name: 'createdAt'))
+    ..add(
+      GqlField(name: 'createdBy')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment)),
+    )
+    ..add(GqlField(name: 'updatedAt'))
+    ..add(
+      GqlField(name: 'updatedBy')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment)),
+    );
+  // coverage:ignore-end
+}
+
+/// [SdmIngredientInput] is the input variant of [SdmIngredient]
+@unfreezed
+abstract class SdmIngredientInput with _$SdmIngredientInput {
+  SdmIngredientInput._();
+
+  factory SdmIngredientInput({
+    /// [id] of the ingredient entity. This ID is unique.
+    String? id,
+
+    /// [name] of the ingredient.
+    @Default('') String name,
+
+    /// [code] of the ingredient.
+    @Default('') String code,
+
+    /// [sourceId] is the device id of the ingredient.
+    String? sourceId,
+
+    /// [pricePerKg] is the price of the ingredient per kilogram.
+    @Default(0.0) double pricePerKg,
+
+    /// [dryFactor] is the dry factor of the ingredient.
+    @Default(1.0) double dryFactor,
+
+    /// [priceByDry] indicates if the price should be calculated using dry or wet weight.
+    @Default(false) bool priceByDry,
+
+    /// [isArchived] is the status of the ingredient.
+    @Default(false) bool isArchived,
+  }) = _SdmIngredientInput;
+
+  factory SdmIngredientInput.fromJson(Map<String, dynamic> json) => _$SdmIngredientInputFromJson(json);
+
+  // coverage:ignore-start
+  /// [save] creates or updates this SDM ingredient on the server
+  Future<(ApiStatus, Map<String, dynamic>?, SdmIngredient?)> save({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    final operation = id == null ? 'addSdmIngredient' : 'editSdmIngredient';
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'data', type: GqlVariableType.input(of: 'SdmIngredientInput'), isRequired: true, value: toJson()),
+          ],
+          name: operation,
+        )..add(
+          GqlField(name: operation, args: {'data': 'data'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'result', fragment: SdmIngredient.fragment)),
+        ),
+        _sdmIngredientDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        return (ApiStatus.internalError, null, null);
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors, null);
+      }
+
+      return (response.status, response.errors, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmIngredientInput/save(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null, null);
+    }
+  }
+  // coverage:ignore-end
 }

--- a/lib/src/sdm/src/operator.dart
+++ b/lib/src/sdm/src/operator.dart
@@ -1,7 +1,19 @@
 part of '../sdm.dart';
 
+SdmOperator _sdmOperatorDecoder(Object? json) {
+  return SdmOperator.fromJson(json as Map<String, dynamic>);
+}
+
+List<SdmOperator> _sdmOperatorListDecoder(Object? json) {
+  return List<SdmOperator>.from(
+    (json as List? ?? []).map((e) => SdmOperator.fromJson(Map<String, dynamic>.from(e as Map))),
+  );
+}
+
 @freezed
 abstract class SdmOperator with _$SdmOperator {
+  const SdmOperator._();
+
   const factory SdmOperator({
     /// [id] of the pen entity. This ID is unique.
     required String id,
@@ -26,4 +38,220 @@ abstract class SdmOperator with _$SdmOperator {
   }) = _SdmOperator;
 
   factory SdmOperator.fromJson(Map<String, dynamic> json) => _$SdmOperatorFromJson(json);
+
+  // coverage:ignore-start
+  /// [fetchAll] fetches all SDM operators from the server
+  static Future<List<SdmOperator>> fetchAll({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(variables: [])..add(
+          GqlField(name: 'sdmOperators', args: {})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _sdmOperatorListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return [];
+      }
+
+      return response.result ?? [];
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmOperator/fetchAll(): General exception => $e\n$stack");
+      return [];
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fetch] fetches a single SDM operator by ID from the server
+  static Future<SdmOperator?> fetch({
+    /// [id] is the ID of the SDM operator to fetch
+    required String id,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [
+            GqlVariable(name: 'id', type: .id, isRequired: true, value: id),
+          ],
+        )..add(
+          GqlField(name: 'sdmOperators', args: {'id': 'id'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _sdmOperatorListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return null;
+      }
+
+      final resultList = response.result;
+      if (resultList == null || resultList.isEmpty) {
+        Log.warning("layrz_models/SdmOperator/fetch(): No result in list");
+        return null;
+      }
+      return resultList.first;
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmOperator/fetch(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [deleteMultiple] deletes multiple SDM operators by ID from the server
+  static Future<bool> deleteMultiple({
+    /// [ids] are the IDs of the SDM operators to delete
+    required List<String> ids,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'ids', type: GqlVariableType.list(of: .id), isRequired: true, value: ids),
+          ],
+          name: 'deleteSdmOperators',
+        )..add(
+          GqlField(name: 'deleteSdmOperators', args: {'ids': 'ids'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmOperator/deleteMultiple(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fragment] is the GqlFragment for an SDM operator
+  static GqlFragment get fragment => GqlFragment(name: 'sdmOperatorFragment', onType: 'SdmOperator')
+    ..add(GqlField(name: 'id'))
+    ..add(GqlField(name: 'name'))
+    ..add(GqlField(name: 'code'))
+    ..add(GqlField(name: 'createdAt'))
+    ..add(
+      GqlField(name: 'createdBy')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment)),
+    )
+    ..add(GqlField(name: 'updatedAt'))
+    ..add(
+      GqlField(name: 'updatedBy')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment)),
+    );
+  // coverage:ignore-end
+}
+
+/// [SdmOperatorInput] is the input variant of [SdmOperator]
+@unfreezed
+abstract class SdmOperatorInput with _$SdmOperatorInput {
+  SdmOperatorInput._();
+
+  factory SdmOperatorInput({
+    /// [id] of the operator entity. This ID is unique.
+    String? id,
+
+    /// [name] of the operator.
+    @Default('') String name,
+
+    /// [code] of the operator.
+    @Default('') String code,
+  }) = _SdmOperatorInput;
+
+  factory SdmOperatorInput.fromJson(Map<String, dynamic> json) => _$SdmOperatorInputFromJson(json);
+
+  // coverage:ignore-start
+  /// [save] creates or updates this SDM operator on the server
+  Future<(ApiStatus, Map<String, dynamic>?, SdmOperator?)> save({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    final operation = id == null ? 'addSdmOperator' : 'editSdmOperator';
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'data', type: GqlVariableType.input(of: 'SdmOperatorInput'), isRequired: true, value: toJson()),
+          ],
+          name: operation,
+        )..add(
+          GqlField(name: operation, args: {'data': 'data'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'result', fragment: SdmOperator.fragment)),
+        ),
+        _sdmOperatorDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        return (ApiStatus.internalError, null, null);
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors, null);
+      }
+
+      return (response.status, response.errors, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmOperatorInput/save(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null, null);
+    }
+  }
+  // coverage:ignore-end
 }

--- a/lib/src/sdm/src/pen.dart
+++ b/lib/src/sdm/src/pen.dart
@@ -1,7 +1,23 @@
 part of '../sdm.dart';
 
+SdmPen _sdmPenDecoder(Object? json) {
+  return SdmPen.fromJson(json as Map<String, dynamic>);
+}
+
+List<SdmPen> _sdmPenListDecoder(Object? json) {
+  return List<SdmPen>.from(
+    (json as List? ?? []).map((e) => SdmPen.fromJson(Map<String, dynamic>.from(e as Map))),
+  );
+}
+
+String? _sdmPenResultUriDecoder(Object? json) {
+  return json as String?;
+}
+
 @freezed
 abstract class SdmPen with _$SdmPen {
+  const SdmPen._();
+
   const factory SdmPen({
     /// [id] of the pen entity. This ID is unique.
     required String id,
@@ -32,4 +48,366 @@ abstract class SdmPen with _$SdmPen {
   }) = _SdmPen;
 
   factory SdmPen.fromJson(Map<String, dynamic> json) => _$SdmPenFromJson(json);
+
+  // coverage:ignore-start
+  /// [fetchAll] fetches all SDM pens from the server
+  static Future<List<SdmPen>> fetchAll({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(variables: [])..add(
+          GqlField(name: 'sdmPens', args: {})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _sdmPenListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return [];
+      }
+
+      return response.result ?? [];
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmPen/fetchAll(): General exception => $e\n$stack");
+      return [];
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fetch] fetches a single SDM pen by ID from the server
+  static Future<SdmPen?> fetch({
+    /// [id] is the ID of the SDM pen to fetch
+    required String id,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [
+            GqlVariable(name: 'id', type: .id, isRequired: true, value: id),
+          ],
+        )..add(
+          GqlField(name: 'sdmPens', args: {'id': 'id'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _sdmPenListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return null;
+      }
+
+      final resultList = response.result;
+      if (resultList == null || resultList.isEmpty) {
+        Log.warning("layrz_models/SdmPen/fetch(): No result in list");
+        return null;
+      }
+      return resultList.first;
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmPen/fetch(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [deleteMultiple] deletes multiple SDM pens by ID from the server
+  static Future<bool> deleteMultiple({
+    /// [ids] are the IDs of the SDM pens to delete
+    required List<String> ids,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'ids', type: GqlVariableType.list(of: .id), isRequired: true, value: ids),
+          ],
+          name: 'deleteSdmPens',
+        )..add(
+          GqlField(name: 'deleteSdmPens', args: {'ids': 'ids'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmPen/deleteMultiple(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [bulkLoad] loads SDM pens from a base64-encoded file
+  static Future<(ApiStatus, Map<String, dynamic>?)> bulkLoad({
+    /// [file] is the base64-encoded file content
+    required String file,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'file', type: .string, isRequired: true, value: file),
+          ],
+          name: 'bulkLoadSdmPens',
+        )..add(
+          GqlField(name: 'bulkLoadSdmPens', args: {'file': 'file'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors);
+      }
+
+      return (response.status, response.errors);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmPen/bulkLoad(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [export] exports SDM pens to a downloadable file
+  static Future<(ApiStatus, String?)> export({
+    /// [languageId] is the language ID for the export
+    required String languageId,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'languageId', type: .id, isRequired: true, value: languageId),
+          ],
+          name: 'exportSdmPens',
+        )..add(
+          GqlField(name: 'exportSdmPens', args: {'languageId': 'languageId'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'resultUri', alias: 'result')),
+        ),
+        _sdmPenResultUriDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, null);
+      }
+
+      return (response.status, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmPen/export(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [formatExcel] formats and downloads an SDM pens Excel template
+  static Future<(ApiStatus, String?)> formatExcel({
+    /// [languageId] is the language ID for the template
+    required String languageId,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'languageId', type: .id, isRequired: true, value: languageId),
+          ],
+          name: 'sdmPensFormatExcel',
+        )..add(
+          GqlField(name: 'sdmPensFormatExcel', args: {'languageId': 'languageId'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'resultUri', alias: 'result')),
+        ),
+        _sdmPenResultUriDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, null);
+      }
+
+      return (response.status, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmPen/formatExcel(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fragment] is the GqlFragment for an SDM pen
+  static GqlFragment get fragment => GqlFragment(name: 'sdmPenFragment', onType: 'SdmPen')
+    ..add(GqlField(name: 'id'))
+    ..add(GqlField(name: 'name'))
+    ..add(GqlField(name: 'code'))
+    ..add(GqlField(name: 'sourceId'))
+    ..add(
+      GqlField(name: 'source')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'ident')),
+    )
+    ..add(GqlField(name: 'createdAt'))
+    ..add(
+      GqlField(name: 'createdBy')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment)),
+    )
+    ..add(GqlField(name: 'updatedAt'))
+    ..add(
+      GqlField(name: 'updatedBy')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment)),
+    );
+  // coverage:ignore-end
+}
+
+/// [SdmPenInput] is the input variant of [SdmPen]
+@unfreezed
+abstract class SdmPenInput with _$SdmPenInput {
+  SdmPenInput._();
+
+  factory SdmPenInput({
+    /// [id] of the pen entity. This ID is unique.
+    String? id,
+
+    /// [name] of the pen.
+    @Default('') String name,
+
+    /// [code] of the pen.
+    @Default('') String code,
+
+    /// [sourceId] is the device id of the pen.
+    String? sourceId,
+
+    /// [pensHeadCountStimated] is the estimated count of pen heads.
+    int? pensHeadCountStimated,
+  }) = _SdmPenInput;
+
+  factory SdmPenInput.fromJson(Map<String, dynamic> json) => _$SdmPenInputFromJson(json);
+
+  // coverage:ignore-start
+  /// [save] creates or updates this SDM pen on the server
+  Future<(ApiStatus, Map<String, dynamic>?, SdmPen?)> save({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    final operation = id == null ? 'addSdmPen' : 'editSdmPen';
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'data', type: GqlVariableType.input(of: 'SdmPenInput'), isRequired: true, value: toJson()),
+          ],
+          name: operation,
+        )..add(
+          GqlField(name: operation, args: {'data': 'data'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'result', fragment: SdmPen.fragment)),
+        ),
+        _sdmPenDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        return (ApiStatus.internalError, null, null);
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors, null);
+      }
+
+      return (response.status, response.errors, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmPenInput/save(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null, null);
+    }
+  }
+  // coverage:ignore-end
 }

--- a/lib/src/sdm/src/recipe.dart
+++ b/lib/src/sdm/src/recipe.dart
@@ -1,7 +1,23 @@
 part of '../sdm.dart';
 
+SdmRecipe _sdmRecipeDecoder(Object? json) {
+  return SdmRecipe.fromJson(json as Map<String, dynamic>);
+}
+
+List<SdmRecipe> _sdmRecipeListDecoder(Object? json) {
+  return List<SdmRecipe>.from(
+    (json as List? ?? []).map((e) => SdmRecipe.fromJson(Map<String, dynamic>.from(e as Map))),
+  );
+}
+
+String? _sdmRecipeResultUriDecoder(Object? json) {
+  return json as String?;
+}
+
 @freezed
 abstract class SdmRecipe with _$SdmRecipe {
+  const SdmRecipe._();
+
   const factory SdmRecipe({
     /// [id] of the pen entity. This ID is unique.
     required String id,
@@ -38,4 +54,373 @@ abstract class SdmRecipe with _$SdmRecipe {
   }) = _SdmRecipe;
 
   factory SdmRecipe.fromJson(Map<String, dynamic> json) => _$SdmRecipeFromJson(json);
+
+  // coverage:ignore-start
+  /// [fetchAll] fetches all SDM recipes from the server
+  static Future<List<SdmRecipe>> fetchAll({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(variables: [])..add(
+          GqlField(name: 'sdmRecipes', args: {})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _sdmRecipeListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return [];
+      }
+
+      return response.result ?? [];
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmRecipe/fetchAll(): General exception => $e\n$stack");
+      return [];
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fetch] fetches a single SDM recipe by ID from the server
+  static Future<SdmRecipe?> fetch({
+    /// [id] is the ID of the SDM recipe to fetch
+    required String id,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [
+            GqlVariable(name: 'id', type: .id, isRequired: true, value: id),
+          ],
+        )..add(
+          GqlField(name: 'sdmRecipes', args: {'id': 'id'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _sdmRecipeListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return null;
+      }
+
+      final resultList = response.result;
+      if (resultList == null || resultList.isEmpty) {
+        Log.warning("layrz_models/SdmRecipe/fetch(): No result in list");
+        return null;
+      }
+      return resultList.first;
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmRecipe/fetch(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [deleteMultiple] deletes multiple SDM recipes by ID from the server
+  static Future<bool> deleteMultiple({
+    /// [ids] are the IDs of the SDM recipes to delete
+    required List<String> ids,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'ids', type: GqlVariableType.list(of: .id), isRequired: true, value: ids),
+          ],
+          name: 'deleteSdmRecipes',
+        )..add(
+          GqlField(name: 'deleteSdmRecipes', args: {'ids': 'ids'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmRecipe/deleteMultiple(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [bulkLoad] loads SDM recipes from a base64-encoded file
+  static Future<(ApiStatus, Map<String, dynamic>?)> bulkLoad({
+    /// [file] is the base64-encoded file content
+    required String file,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'file', type: .string, isRequired: true, value: file),
+          ],
+          name: 'bulkLoadSdmRecipes',
+        )..add(
+          GqlField(name: 'bulkLoadSdmRecipes', args: {'file': 'file'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors);
+      }
+
+      return (response.status, response.errors);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmRecipe/bulkLoad(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [export] exports SDM recipes to a downloadable file
+  static Future<(ApiStatus, String?)> export({
+    /// [languageId] is the language ID for the export
+    required String languageId,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'languageId', type: .id, isRequired: true, value: languageId),
+          ],
+          name: 'exportSdmRecipes',
+        )..add(
+          GqlField(name: 'exportSdmRecipes', args: {'languageId': 'languageId'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'resultUri', alias: 'result')),
+        ),
+        _sdmRecipeResultUriDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, null);
+      }
+
+      return (response.status, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmRecipe/export(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [formatExcel] formats and downloads an SDM recipes Excel template
+  static Future<(ApiStatus, String?)> formatExcel({
+    /// [languageId] is the language ID for the template
+    required String languageId,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'languageId', type: .id, isRequired: true, value: languageId),
+          ],
+          name: 'sdmRecipesFormatExcel',
+        )..add(
+          GqlField(name: 'sdmRecipesFormatExcel', args: {'languageId': 'languageId'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'resultUri', alias: 'result')),
+        ),
+        _sdmRecipeResultUriDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, null);
+      }
+
+      return (response.status, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmRecipe/formatExcel(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fragment] is the GqlFragment for an SDM recipe
+  static GqlFragment get fragment => GqlFragment(name: 'sdmRecipeFragment', onType: 'SdmRecipe')
+    ..add(GqlField(name: 'id'))
+    ..add(GqlField(name: 'name'))
+    ..add(GqlField(name: 'code'))
+    ..add(GqlField(name: 'sourceId'))
+    ..add(
+      GqlField(name: 'source')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'ident')),
+    )
+    ..add(
+      GqlField(name: 'ingredients')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'code')),
+    )
+    ..add(GqlField(name: 'ingredientsIds'))
+    ..add(GqlField(name: 'createdAt'))
+    ..add(
+      GqlField(name: 'createdBy')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment)),
+    )
+    ..add(GqlField(name: 'updatedAt'))
+    ..add(
+      GqlField(name: 'updatedBy')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment)),
+    );
+  // coverage:ignore-end
+}
+
+/// [SdmRecipeInput] is the input variant of [SdmRecipe]
+@unfreezed
+abstract class SdmRecipeInput with _$SdmRecipeInput {
+  SdmRecipeInput._();
+
+  factory SdmRecipeInput({
+    /// [id] of the recipe entity. This ID is unique.
+    String? id,
+
+    /// [name] of the recipe.
+    @Default('') String name,
+
+    /// [code] of the recipe.
+    @Default('') String code,
+
+    /// [sourceId] is the device id of the recipe.
+    String? sourceId,
+
+    /// [ingredientsIds] is the list of ingredients ids of the recipe.
+    @Default([]) List<String> ingredientsIds,
+  }) = _SdmRecipeInput;
+
+  factory SdmRecipeInput.fromJson(Map<String, dynamic> json) => _$SdmRecipeInputFromJson(json);
+
+  // coverage:ignore-start
+  /// [save] creates or updates this SDM recipe on the server
+  Future<(ApiStatus, Map<String, dynamic>?, SdmRecipe?)> save({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    final operation = id == null ? 'addSdmRecipe' : 'editSdmRecipe';
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'data', type: GqlVariableType.input(of: 'SdmRecipeInput'), isRequired: true, value: toJson()),
+          ],
+          name: operation,
+        )..add(
+          GqlField(name: operation, args: {'data': 'data'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'result', fragment: SdmRecipe.fragment)),
+        ),
+        _sdmRecipeDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        return (ApiStatus.internalError, null, null);
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors, null);
+      }
+
+      return (response.status, response.errors, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/SdmRecipeInput/save(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null, null);
+    }
+  }
+  // coverage:ignore-end
 }

--- a/lib/src/users/src/user.dart
+++ b/lib/src/users/src/user.dart
@@ -632,6 +632,7 @@ abstract class User with _$User {
   }
   // coverage:ignore-end
 
+  // coverage:ignore-start
   /// [loginAs] logs in as a subaccount (delegate login).
   /// Returns a [Token] on success or null on error.
   static Future<Token?> loginAs({

--- a/lib/src/users/src/user.dart
+++ b/lib/src/users/src/user.dart
@@ -1,5 +1,85 @@
 part of '../users.dart';
 
+List<User> _userListDecoder(Object? json) {
+  return List<User>.from(
+    (json as List).map((e) {
+      return User.fromJson(e as Map<String, dynamic>);
+    }),
+  );
+}
+
+User _userDecoder(Object? json) {
+  return User.fromJson(json as Map<String, dynamic>);
+}
+
+String? _stringOrNullDecoder(Object? json) => json as String?;
+
+Map<String, dynamic>? _mapOrNullDecoder(Object? json) =>
+    json == null ? null : Map<String, dynamic>.from(json as Map);
+
+// coverage:ignore-start
+/// [_getSaveMutationName] returns the GraphQL mutation name for saving a user based on the variant and whether it's a new user.
+String _getSaveMutationName({required UserVariant variant, required bool isNew}) {
+  switch (variant) {
+    case .standard:
+    case .ats:
+    case .atsAdmin:
+    case .brickhouse:
+    case .tagon:
+      return isNew ? 'addUser' : 'editUser';
+    case .sdm:
+      return isNew ? 'addSdmUser' : 'editSdmUser';
+    case .mappitOperator:
+    case .mappitCustomer:
+    case .mappitEmployee:
+    case .mappitSupervisor:
+    case .mappitSeller:
+      return isNew ? 'addMappitUser' : 'editMappitUser';
+  }
+}
+
+/// [_getDeleteMutationName] returns the GraphQL mutation name for deleting users based on the variant.
+String _getDeleteMutationName({required UserVariant variant}) {
+  switch (variant) {
+    case .sdm:
+      return 'deleteSdmUsers';
+    case .mappitOperator:
+    case .mappitCustomer:
+    case .mappitEmployee:
+    case .mappitSupervisor:
+    case .mappitSeller:
+      return 'deleteMappitUsers';
+    case .standard:
+    case .ats:
+    case .atsAdmin:
+    case .brickhouse:
+    case .tagon:
+      return 'deleteUsers';
+  }
+}
+
+/// [_getInputTypeName] returns the GraphQL input type name for user input based on the variant.
+String _getInputTypeName({required UserVariant variant}) {
+  switch (variant) {
+    case .sdm:
+      return 'SdmUserInput';
+    case .mappitOperator:
+    case .mappitCustomer:
+    case .mappitEmployee:
+    case .mappitSupervisor:
+    case .mappitSeller:
+      return 'MappitUserInput';
+    case .brickhouse:
+      return 'BHSEditUserInput';
+    case .standard:
+    case .ats:
+    case .atsAdmin:
+    case .tagon:
+      return 'UserInput';
+  }
+}
+// coverage:ignore-end
+
 @freezed
 abstract class User with _$User {
   const User._();
@@ -157,66 +237,330 @@ abstract class User with _$User {
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 
-  /// [gqlFragment] is the lightweight GqlFragment for a user, suitable for listings and pickers.
-  static final GqlFragment gqlFragment = GqlFragment(name: 'userFragment', onType: 'User')
-    ..add(GqlField(name: 'id'))
-    ..add(GqlField(name: 'name'))
-    ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.gqlFragment));
-
-  /// [buildFetchAllQuery] builds the GqlQuery to fetch all users with listing-level fields.
-  static GqlQuery buildFetchAllQuery({required String apiToken}) {
-    return GqlQuery(
-      name: 'users',
-      variables: [],
-    )..add(
-      GqlField(name: 'users')
-        ..add(GqlField(name: 'status'))
-        ..add(GqlField(name: 'errors'))
-        ..add(GqlField(name: 'result', fragment: gqlFragment)),
-    );
+  // coverage:ignore-start
+  /// [_getGqlEntityName] returns the GraphQL entity name based on the user variant.
+  static String _getGqlEntityName({required UserVariant variant}) {
+    switch (variant) {
+      case .standard:
+        return 'User';
+      case .ats:
+      case .atsAdmin:
+        return 'AtsUser';
+      case .brickhouse:
+        return 'BHSUser';
+      case .sdm:
+        return 'SdmUser';
+      case .tagon:
+        return 'TagonUser';
+      case .mappitOperator:
+      case .mappitCustomer:
+      case .mappitEmployee:
+      case .mappitSupervisor:
+      case .mappitSeller:
+        return 'MappitUser';
+    }
   }
 
+  // coverage:ignore-end
+  // coverage:ignore-start
+  /// [_getGqlQueryName] returns the GraphQL query name based on the user variant.
+  static String _getGqlQueryName({required UserVariant variant}) {
+    switch (variant) {
+      case .standard:
+        return 'users';
+      case .ats:
+      case .atsAdmin:
+        return 'atsUsers';
+      case .brickhouse:
+        return 'brickhouseUsers';
+      case .sdm:
+        return 'sdmUsers';
+      case .tagon:
+        return 'tagonUsers';
+      case .mappitOperator:
+      case .mappitCustomer:
+      case .mappitEmployee:
+      case .mappitSupervisor:
+      case .mappitSeller:
+        return 'mappitUsers';
+    }
+  }
+
+  // coverage:ignore-start
+  /// [fragment] is the GqlFragment for a user, with full parity to layrz_users generators.
+  static GqlFragment fragment({required UserVariant variant}) {
+    final gql = GqlFragment(
+      name: 'userFragment',
+      onType: _getGqlEntityName(variant: variant),
+    );
+
+    // Base fields (all variants)
+    gql.add(GqlField(name: 'id'));
+    gql.add(GqlField(name: 'name'));
+    gql.add(GqlField(name: 'email'));
+    gql.add(GqlField(name: 'username'));
+    gql.add(GqlField(name: 'parentId'));
+    gql.add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment));
+    gql.add(GqlField(name: 'referencesIds'));
+    gql.add(GqlField(name: 'categoryId'));
+    gql.add(GqlField(name: 'access', fragment: Access.idFragment));
+    gql.add(GqlField(name: 'tagsIds'));
+
+    // Per-variant additions
+    final isMappit = [
+      UserVariant.mappitOperator,
+      UserVariant.mappitCustomer,
+      UserVariant.mappitSupervisor,
+      UserVariant.mappitEmployee,
+      UserVariant.mappitSeller,
+    ].contains(variant);
+
+    if (isMappit) {
+      gql.add(GqlField(name: 'mappitAssetsIds'));
+      gql.add(
+        GqlField(name: 'mappitAssets', fields: [
+          GqlField(name: 'id'),
+          GqlField(name: 'name'),
+          GqlField(name: 'mode'),
+        ]),
+      );
+      gql.add(GqlField(name: 'historicalDaysAllowed'));
+    } else if (variant == .sdm) {
+      gql.add(GqlField(name: 'sdmCode'));
+    } else if (variant == .brickhouse) {
+      gql.add(GqlField(name: 'suspendedAt'));
+      gql.add(GqlField(name: 'isSuspended'));
+      gql.add(GqlField(name: 'brickhouseRole'));
+      gql.add(GqlField(name: 'brickhousePermissionTierId'));
+      gql.add(
+        GqlField(name: 'brickhousePermissionTier', fields: [
+          GqlField(name: 'id'),
+          GqlField(name: 'name'),
+          GqlField(name: 'tierLevel'),
+          GqlField(name: 'billingPeriod'),
+        ]),
+      );
+    }
+
+    return gql;
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
   /// [fetchAll] fetches all users from the API with a lightweight payload.
   static Future<List<User>> fetchAll({
     required String apiToken,
     required Uri uri,
     void Function(String statusCode)? onResponse,
+    UserVariant variant = .standard,
   }) async {
     final connector = LayrzConnector(uri: uri, apiToken: apiToken);
     try {
-      final response = await connector.perform(buildFetchAllQuery(apiToken: apiToken));
+      final response = await connector.query(
+        GqlQuery(
+          variables: [],
+          name: _getGqlQueryName(variant: variant),
+        )..add(
+          GqlField(name: _getGqlQueryName(variant: variant))
+            ..add(GqlField(name: 'status'))
+            ..add(
+              GqlField(
+                name: 'result',
+                fields: [
+                  GqlField(name: 'id'),
+                  GqlField(name: 'name'),
+                  GqlField(name: 'username'),
+                  GqlField(name: 'email'),
+                  GqlField(name: 'mfaEnabled'),
+                  GqlField(name: 'hasPaymentWarning'),
+                  GqlField(name: 'isLocked'),
+                  GqlField(name: 'isSuspended'),
+                  GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment),
+                  if (variant == .sdm) GqlField(name: 'sdmCode'),
+                ],
+              ),
+            ),
+        ),
+        _userListDecoder,
+      );
 
-      final data = response.data;
-      if (data == null) {
-        onResponse?.call(ApiStatus.internalError.toJson());
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
         Log.error("layrz_models/User/fetchAll(): No response from server");
         return [];
       }
 
-      final result = data['data']['users'];
+      final result = response.result;
       if (result == null) {
         onResponse?.call(ApiStatus.internalError.toJson());
         Log.error("layrz_models/User/fetchAll(): No result from server");
         return [];
       }
 
-      final status = ApiStatus.fromJson(result['status']);
-      if (status != ApiStatus.ok) {
-        onResponse?.call(status.toJson());
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
         return [];
       }
 
-      return (result['result'] as List<dynamic>?)
-              ?.map((e) => User.fromJson(Map<String, dynamic>.from(e as Map)))
-              .toList() ??
-          [];
+      return response.result ?? [];
     } catch (e, stack) {
       Log.critical("layrz_models/User/fetchAll(): General exception => $e\n$stack");
       return [];
     }
   }
+  // coverage:ignore-end
 
+  // coverage:ignore-start
+  /// [fetch] fetches a single user by ID.
+  /// Returns a [User] on success or null on error.
+  /// When [withDetails] is true (default), includes tags, references, category, and allowedApps with full design info.
+  static Future<User?> fetch({
+    required String id,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+    UserVariant variant = .standard,
+    String? appId,
+    bool withDetails = true,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final variables = <GqlVariable>[
+        GqlVariable(name: 'id', type: .id, isRequired: true, value: id),
+      ];
+      if (appId != null) {
+        variables.add(GqlVariable(name: 'appId', type: .id, isRequired: false, value: appId));
+      }
+
+      final resultField = GqlField(
+        name: 'result',
+        fragment: fragment(variant: variant),
+      );
+
+      // Add details fields when withDetails is true
+      if (withDetails) {
+        resultField.add(
+          GqlField(name: 'tags', fields: [
+            GqlField(name: 'id'),
+            GqlField(name: 'name'),
+            GqlField(name: 'color'),
+            GqlField(name: 'icon'),
+          ]),
+        );
+        resultField.add(
+          GqlField(name: 'references', fields: [
+            GqlField(name: 'id'),
+            GqlField(name: 'name'),
+          ]),
+        );
+        resultField.add(GqlField(name: 'categoryId'));
+        resultField.add(
+          GqlField(name: 'category', fields: [
+            GqlField(name: 'id'),
+            GqlField(name: 'name'),
+            GqlField(name: 'kind'),
+          ]),
+        );
+        resultField.add(
+          GqlField(name: 'allowedApps', fields: [
+            GqlField(name: 'id'),
+            GqlField(name: 'name'),
+            GqlField(name: 'nickname'),
+            GqlField(name: 'technology'),
+            GqlField(name: 'sourceId'),
+            GqlField(
+              name: 'designInformation',
+              fields: [
+                GqlField(
+                  name: 'favicons',
+                  fields: [
+                    GqlField(name: 'white'),
+                    GqlField(name: 'normal'),
+                  ],
+                ),
+                GqlField(
+                  name: 'logos',
+                  fields: [
+                    GqlField(name: 'white'),
+                    GqlField(name: 'normal'),
+                  ],
+                ),
+                GqlField(
+                  name: 'colors',
+                  fields: [
+                    GqlField(name: 'theme'),
+                    GqlField(name: 'mainColor'),
+                    GqlField(name: 'primary'),
+                    GqlField(name: 'secondary'),
+                    GqlField(name: 'accent'),
+                  ],
+                ),
+                GqlField(name: 'appicon'),
+              ],
+            ),
+            GqlField(
+              name: 'instances',
+              fields: [
+                GqlField(name: 'id'),
+                GqlField(name: 'appId'),
+                GqlField(name: 'platform'),
+                GqlField(name: 'appIdentifier'),
+                GqlField(name: 'host'),
+                GqlField(name: 'status'),
+                GqlField(name: 'migrationStatus'),
+              ],
+            ),
+          ]),
+        );
+      }
+
+      final response = await connector.query(
+        GqlQuery(
+          variables: variables,
+          name: _getGqlQueryName(variant: variant),
+        )..add(
+          GqlField(
+              name: _getGqlQueryName(variant: variant),
+              args: {
+                'id': 'id',
+                if (appId != null) 'appId': 'appId',
+              },
+            )
+            ..add(GqlField(name: 'status'))
+            ..add(resultField),
+        ),
+        _userListDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        Log.error("layrz_models/User/fetch(): No response from server");
+        return null;
+      }
+
+      final result = response.result;
+      if (result == null) {
+        onResponse?.call(ApiStatus.internalError.toJson());
+        Log.error("layrz_models/User/fetch(): No result from server");
+        return null;
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return null;
+      }
+
+      return result.isNotEmpty ? result.first : null;
+    } catch (e, stack) {
+      Log.critical("layrz_models/User/fetch(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
   /// [fetchAllForAppUsers] fetches all users for app user management (includes username and email).
+  /// Always uses the standard `users` query; not variant-aware by design.
   /// Returns a list of [User] on success, empty list on error.
   static Future<List<User>> fetchAllForAppUsers({
     required String apiToken,
@@ -225,7 +569,7 @@ abstract class User with _$User {
   }) async {
     final connector = LayrzConnector(uri: uri, apiToken: apiToken);
     try {
-      final response = await connector.perform(
+      final response = await connector.query(
         GqlQuery(
           variables: [],
           name: 'users',
@@ -238,40 +582,37 @@ abstract class User with _$User {
                 ..add(GqlField(name: 'name'))
                 ..add(GqlField(name: 'username'))
                 ..add(GqlField(name: 'email'))
-                ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.gqlFragment)),
+                ..add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment)),
             ),
         ),
+        _userListDecoder,
       );
 
-      final data = response.data;
-      if (data == null) {
-        onResponse?.call(ApiStatus.internalError.toJson());
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
         Log.error("layrz_models/User/fetchAllForAppUsers(): No response from server");
         return [];
       }
 
-      final result = data['data']['users'];
+      final result = response.result;
       if (result == null) {
         onResponse?.call(ApiStatus.internalError.toJson());
         Log.error("layrz_models/User/fetchAllForAppUsers(): No result from server");
         return [];
       }
 
-      final status = ApiStatus.fromJson(result['status']);
-      if (status != ApiStatus.ok) {
-        onResponse?.call(status.toJson());
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
         return [];
       }
 
-      return (result['result'] as List<dynamic>?)
-              ?.map((e) => User.fromJson(Map<String, dynamic>.from(e as Map)))
-              .toList() ??
-          [];
+      return response.result ?? [];
     } catch (e, stack) {
       Log.critical("layrz_models/User/fetchAllForAppUsers(): General exception => $e\n$stack");
       return [];
     }
   }
+  // coverage:ignore-end
 
   /// [loginAs] logs in as a subaccount (delegate login).
   /// Returns a [Token] on success or null on error.
@@ -329,6 +670,399 @@ abstract class User with _$User {
       return null;
     }
   }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [deleteMultiple] deletes multiple users by their IDs.
+  /// Returns true on success, false on error.
+  /// [mappitModule] is required for mappit variants when provided; specifies which Mappit module to delete from.
+  static Future<bool> deleteMultiple({
+    required List<String> ids,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+    UserVariant variant = .standard,
+    String? appId,
+    String? mappitModule,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final isMappit = [
+        UserVariant.mappitOperator,
+        UserVariant.mappitCustomer,
+        UserVariant.mappitSupervisor,
+        UserVariant.mappitEmployee,
+        UserVariant.mappitSeller,
+      ].contains(variant);
+
+      final variables = <GqlVariable>[
+        GqlVariable(
+          name: 'ids',
+          type: .list(of: .id, isRequired: true),
+          isRequired: true,
+          value: ids,
+        ),
+      ];
+      if (appId != null) {
+        variables.add(GqlVariable(name: 'appId', type: .id, isRequired: false, value: appId));
+      }
+      if (isMappit && mappitModule != null) {
+        variables.add(
+          GqlVariable(
+            name: 'module',
+            type: GqlVariableType.enum_(of: 'MappitUserModule'),
+            isRequired: true,
+            value: mappitModule,
+          ),
+        );
+      }
+
+      final args = <String, String>{
+        'ids': 'ids',
+        if (appId != null) 'appId': 'appId',
+        if (isMappit && mappitModule != null) 'module': 'module',
+      };
+
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: variables,
+          name: _getDeleteMutationName(variant: variant),
+        )..add(
+          GqlField(
+            name: _getDeleteMutationName(variant: variant),
+            args: args,
+          )..add(GqlField(name: 'status')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/User/deleteMultiple(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [importIntoApp] imports a list of users into an app.
+  /// Returns true on success, false on error.
+  static Future<bool> importIntoApp({
+    required String appId,
+    required List<String> usersIds,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'appId', type: .id, isRequired: true, value: appId),
+            GqlVariable(
+              name: 'usersIds',
+              type: .list(of: .id, isRequired: true),
+              isRequired: true,
+              value: usersIds,
+            ),
+          ],
+          name: 'importUsersIntoApp',
+        )..add(
+          GqlField(
+            name: 'importUsersIntoApp',
+            args: {'appId': 'appId', 'usersIds': 'usersIds'},
+          )
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/User/importIntoApp(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [resetPassword] sends a password reset request for a user.
+  /// Returns true on success, false on error.
+  static Future<bool> resetPassword({
+    required String userId,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'userId', type: .id, isRequired: true, value: userId),
+          ],
+          name: 'resetPassword',
+        )..add(
+          GqlField(
+            name: 'resetPassword',
+            args: {'userId': 'userId'},
+          )
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/User/resetPassword(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [setPaymentWarning] sets or clears the payment warning flag for a user.
+  /// Returns true on success, false on error.
+  static Future<bool> setPaymentWarning({
+    required String userId,
+    required bool state,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'userId', type: .id, isRequired: true, value: userId),
+            GqlVariable(name: 'state', type: .boolean, isRequired: true, value: state),
+          ],
+          name: 'setPaymentWarningToUser',
+        )..add(
+          GqlField(
+            name: 'setPaymentWarningToUser',
+            args: {'userId': 'userId', 'state': 'state'},
+          )
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/User/setPaymentWarning(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [lock] locks or unlocks a user account.
+  /// Returns true on success, false on error.
+  static Future<bool> lock({
+    required String userId,
+    required bool state,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'userId', type: .id, isRequired: true, value: userId),
+            GqlVariable(name: 'state', type: .boolean, isRequired: true, value: state),
+          ],
+          name: 'lockUserAccount',
+        )..add(
+          GqlField(
+            name: 'lockUserAccount',
+            args: {'userId': 'userId', 'state': 'state'},
+          )
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/User/lock(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [suspend] suspends or reactivates a user account.
+  /// Returns true on success, false on error.
+  static Future<bool> suspend({
+    required String userId,
+    required bool state,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'userId', type: .id, isRequired: true, value: userId),
+            GqlVariable(name: 'state', type: .boolean, isRequired: true, value: state),
+          ],
+          name: 'suspendUserAccount',
+        )..add(
+          GqlField(
+            name: 'suspendUserAccount',
+            args: {'userId': 'userId', 'state': 'state'},
+          )
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/User/suspend(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [invite] sends an invitation email to a user by email address.
+  /// Returns a record with status and the generated invite link (or null on error).
+  static Future<(ApiStatus, String?)> invite({
+    String? email,
+    String? languageId,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final variables = <GqlVariable>[];
+      if (email != null) {
+        variables.add(GqlVariable(name: 'email', type: .string, isRequired: false, value: email));
+      }
+      if (languageId != null) {
+        variables.add(GqlVariable(name: 'languageId', type: .id, isRequired: false, value: languageId));
+      }
+
+      final args = <String, String>{};
+      if (email != null) args['email'] = 'email';
+      if (languageId != null) args['languageId'] = 'languageId';
+
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: variables,
+          name: 'inviteUser',
+        )..add(
+          GqlField(
+            name: 'inviteUser',
+            args: args,
+          )
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'inviteLink', alias: 'result')),
+        ),
+        _stringOrNullDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, null);
+      }
+
+      return (response.status, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/User/invite(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [requestActivityReport] requests an activity report for a user.
+  /// Returns a record with status, uri, and data from the report (or nulls on error).
+  static Future<(ApiStatus, String?, dynamic)> requestActivityReport({
+    required String userId,
+    String? languageId,
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final variables = <GqlVariable>[
+        GqlVariable(name: 'userId', type: .id, isRequired: true, value: userId),
+      ];
+      if (languageId != null) {
+        variables.add(GqlVariable(name: 'languageId', type: .id, isRequired: false, value: languageId));
+      }
+
+      final args = <String, String>{'userId': 'userId'};
+      if (languageId != null) args['languageId'] = 'languageId';
+
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: variables,
+          name: 'requestActivityReport',
+        )..add(
+          GqlField(
+            name: 'requestActivityReport',
+            args: args,
+          )
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(
+              GqlField(name: 'result')
+                ..add(GqlField(name: 'uri'))
+                ..add(GqlField(name: 'data')),
+            ),
+        ),
+        _mapOrNullDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, null, null);
+      }
+
+      return (response.status, response.result?['uri'] as String?, response.result?['data']);
+    } catch (e, stack) {
+      Log.critical("layrz_models/User/requestActivityReport(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null, null);
+    }
+  }
+  // coverage:ignore-end
 }
 
 @unfreezed
@@ -388,4 +1122,123 @@ abstract class UserInput with _$UserInput {
   }) = _UserInput;
 
   factory UserInput.fromJson(Map<String, dynamic> json) => _$UserInputFromJson(json);
+
+  // coverage:ignore-start
+  /// [save] saves a user (add or edit) and returns a record with status, errors, and the saved user.
+  /// Returns `(ApiStatus, Map<String, dynamic>?, User?)` — on internalError: (internalError, null, null);
+  /// on other error: (status, errors, null); on success: (status, errors, user).
+  /// [languageId] is optional and only sent when creating a new user.
+  /// [mappitModule] is required for mappit variants when provided; specifies which Mappit module to save to.
+  Future<(ApiStatus, Map<String, dynamic>?, User?)> save({
+    required String apiToken,
+    required Uri uri,
+    void Function(String statusCode)? onResponse,
+    UserVariant variant = .standard,
+    String? appId,
+    String? languageId,
+    String? mappitModule,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final isNew = id == null;
+      final operation = _getSaveMutationName(variant: variant, isNew: isNew);
+
+      final isMappit = [
+        UserVariant.mappitOperator,
+        UserVariant.mappitCustomer,
+        UserVariant.mappitSupervisor,
+        UserVariant.mappitEmployee,
+        UserVariant.mappitSeller,
+      ].contains(variant);
+
+      // Build payload with field-stripping based on variant
+      final payload = toJson();
+
+      // Strip mappit-only fields if not mappit variant
+      if (!isMappit) {
+        payload.remove('historicalDaysAllowed');
+        payload.remove('mappitAssetsIds');
+      }
+
+      // Strip variant-specific fields
+      if (variant == .brickhouse) {
+        payload.remove('sdmCode');
+        payload.remove('preferences');
+      } else {
+        // For non-brickhouse variants, remove brickhouse fields
+        payload.remove('brickhousePermissionTierId');
+        payload.remove('brickhouseRole');
+      }
+
+      final variables = <GqlVariable>[
+        GqlVariable(
+          name: 'data',
+          type: GqlVariableType.input(of: _getInputTypeName(variant: variant)),
+          isRequired: true,
+          value: payload,
+        ),
+      ];
+      if (appId != null) {
+        variables.add(GqlVariable(name: 'appId', type: .id, isRequired: false, value: appId));
+      }
+      if (isNew && languageId != null) {
+        variables.add(GqlVariable(name: 'languageId', type: .id, isRequired: false, value: languageId));
+      }
+      if (isMappit && mappitModule != null) {
+        variables.add(
+          GqlVariable(
+            name: 'module',
+            type: GqlVariableType.enum_(of: 'MappitUserModule'),
+            isRequired: true,
+            value: mappitModule,
+          ),
+        );
+      }
+
+      final args = <String, String>{
+        'data': 'data',
+        if (appId != null) 'appId': 'appId',
+        if (isNew && languageId != null) 'languageId': 'languageId',
+        if (isMappit && mappitModule != null) 'module': 'module',
+      };
+
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: variables,
+          name: operation,
+        )..add(
+          GqlField(
+              name: operation,
+              args: args,
+            )
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(
+              GqlField(
+                name: 'result',
+                fragment: User.fragment(variant: variant),
+              ),
+            ),
+        ),
+        _userDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        return (ApiStatus.internalError, null, null);
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors, null);
+      }
+
+      return (response.status, response.errors, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/User/save(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null, null);
+    }
+  }
+
+  // coverage:ignore-end
 }

--- a/lib/src/users/src/user.dart
+++ b/lib/src/users/src/user.dart
@@ -14,8 +14,7 @@ User _userDecoder(Object? json) {
 
 String? _stringOrNullDecoder(Object? json) => json as String?;
 
-Map<String, dynamic>? _mapOrNullDecoder(Object? json) =>
-    json == null ? null : Map<String, dynamic>.from(json as Map);
+Map<String, dynamic>? _mapOrNullDecoder(Object? json) => json == null ? null : Map<String, dynamic>.from(json as Map);
 
 // coverage:ignore-start
 /// [_getSaveMutationName] returns the GraphQL mutation name for saving a user based on the variant and whether it's a new user.
@@ -285,6 +284,7 @@ abstract class User with _$User {
         return 'mappitUsers';
     }
   }
+  // coverage:ignore-end
 
   // coverage:ignore-start
   /// [fragment] is the GqlFragment for a user, with full parity to layrz_users generators.
@@ -318,11 +318,14 @@ abstract class User with _$User {
     if (isMappit) {
       gql.add(GqlField(name: 'mappitAssetsIds'));
       gql.add(
-        GqlField(name: 'mappitAssets', fields: [
-          GqlField(name: 'id'),
-          GqlField(name: 'name'),
-          GqlField(name: 'mode'),
-        ]),
+        GqlField(
+          name: 'mappitAssets',
+          fields: [
+            GqlField(name: 'id'),
+            GqlField(name: 'name'),
+            GqlField(name: 'mode'),
+          ],
+        ),
       );
       gql.add(GqlField(name: 'historicalDaysAllowed'));
     } else if (variant == .sdm) {
@@ -333,12 +336,15 @@ abstract class User with _$User {
       gql.add(GqlField(name: 'brickhouseRole'));
       gql.add(GqlField(name: 'brickhousePermissionTierId'));
       gql.add(
-        GqlField(name: 'brickhousePermissionTier', fields: [
-          GqlField(name: 'id'),
-          GqlField(name: 'name'),
-          GqlField(name: 'tierLevel'),
-          GqlField(name: 'billingPeriod'),
-        ]),
+        GqlField(
+          name: 'brickhousePermissionTier',
+          fields: [
+            GqlField(name: 'id'),
+            GqlField(name: 'name'),
+            GqlField(name: 'tierLevel'),
+            GqlField(name: 'billingPeriod'),
+          ],
+        ),
       );
     }
 
@@ -440,77 +446,89 @@ abstract class User with _$User {
       // Add details fields when withDetails is true
       if (withDetails) {
         resultField.add(
-          GqlField(name: 'tags', fields: [
-            GqlField(name: 'id'),
-            GqlField(name: 'name'),
-            GqlField(name: 'color'),
-            GqlField(name: 'icon'),
-          ]),
+          GqlField(
+            name: 'tags',
+            fields: [
+              GqlField(name: 'id'),
+              GqlField(name: 'name'),
+              GqlField(name: 'color'),
+              GqlField(name: 'icon'),
+            ],
+          ),
         );
         resultField.add(
-          GqlField(name: 'references', fields: [
-            GqlField(name: 'id'),
-            GqlField(name: 'name'),
-          ]),
+          GqlField(
+            name: 'references',
+            fields: [
+              GqlField(name: 'id'),
+              GqlField(name: 'name'),
+            ],
+          ),
         );
         resultField.add(GqlField(name: 'categoryId'));
         resultField.add(
-          GqlField(name: 'category', fields: [
-            GqlField(name: 'id'),
-            GqlField(name: 'name'),
-            GqlField(name: 'kind'),
-          ]),
+          GqlField(
+            name: 'category',
+            fields: [
+              GqlField(name: 'id'),
+              GqlField(name: 'name'),
+              GqlField(name: 'kind'),
+            ],
+          ),
         );
         resultField.add(
-          GqlField(name: 'allowedApps', fields: [
-            GqlField(name: 'id'),
-            GqlField(name: 'name'),
-            GqlField(name: 'nickname'),
-            GqlField(name: 'technology'),
-            GqlField(name: 'sourceId'),
-            GqlField(
-              name: 'designInformation',
-              fields: [
-                GqlField(
-                  name: 'favicons',
-                  fields: [
-                    GqlField(name: 'white'),
-                    GqlField(name: 'normal'),
-                  ],
-                ),
-                GqlField(
-                  name: 'logos',
-                  fields: [
-                    GqlField(name: 'white'),
-                    GqlField(name: 'normal'),
-                  ],
-                ),
-                GqlField(
-                  name: 'colors',
-                  fields: [
-                    GqlField(name: 'theme'),
-                    GqlField(name: 'mainColor'),
-                    GqlField(name: 'primary'),
-                    GqlField(name: 'secondary'),
-                    GqlField(name: 'accent'),
-                  ],
-                ),
-                GqlField(name: 'appicon'),
-              ],
-            ),
-            GqlField(
-              name: 'instances',
-              fields: [
-                GqlField(name: 'id'),
-                GqlField(name: 'appId'),
-                GqlField(name: 'platform'),
-                GqlField(name: 'appIdentifier'),
-                GqlField(name: 'host'),
-                GqlField(name: 'status'),
-                GqlField(name: 'migrationStatus'),
-              ],
-            ),
-          ]),
+          GqlField(
+            name: 'allowedApps',
+            fields: [
+              GqlField(name: 'id'),
+              GqlField(name: 'name'),
+              GqlField(name: 'nickname'),
+              GqlField(name: 'technology'),
+              GqlField(name: 'sourceId'),
+              GqlField(
+                name: 'designInformation',
+                fields: [
+                  GqlField(
+                    name: 'favicons',
+                    fields: [
+                      GqlField(name: 'white'),
+                      GqlField(name: 'normal'),
+                    ],
+                  ),
+                  GqlField(
+                    name: 'logos',
+                    fields: [
+                      GqlField(name: 'white'),
+                      GqlField(name: 'normal'),
+                    ],
+                  ),
+                  GqlField(
+                    name: 'colors',
+                    fields: [
+                      GqlField(name: 'theme'),
+                      GqlField(name: 'mainColor'),
+                      GqlField(name: 'primary'),
+                      GqlField(name: 'secondary'),
+                      GqlField(name: 'accent'),
+                    ],
+                  ),
+                  GqlField(name: 'appicon'),
+                ],
+              ),
+              GqlField(
+                name: 'instances',
+                fields: [
+                  GqlField(name: 'id'),
+                  GqlField(name: 'appId'),
+                  GqlField(name: 'platform'),
+                  GqlField(name: 'appIdentifier'),
+                  GqlField(name: 'host'),
+                  GqlField(name: 'status'),
+                  GqlField(name: 'migrationStatus'),
+                ],
+              ),
+            ],
+          ),
         );
       }
 
@@ -774,9 +792,9 @@ abstract class User with _$User {
           name: 'importUsersIntoApp',
         )..add(
           GqlField(
-            name: 'importUsersIntoApp',
-            args: {'appId': 'appId', 'usersIds': 'usersIds'},
-          )
+              name: 'importUsersIntoApp',
+              args: {'appId': 'appId', 'usersIds': 'usersIds'},
+            )
             ..add(GqlField(name: 'status'))
             ..add(GqlField(name: 'errors')),
         ),
@@ -813,9 +831,9 @@ abstract class User with _$User {
           name: 'resetPassword',
         )..add(
           GqlField(
-            name: 'resetPassword',
-            args: {'userId': 'userId'},
-          )
+              name: 'resetPassword',
+              args: {'userId': 'userId'},
+            )
             ..add(GqlField(name: 'status'))
             ..add(GqlField(name: 'errors')),
         ),
@@ -854,9 +872,9 @@ abstract class User with _$User {
           name: 'setPaymentWarningToUser',
         )..add(
           GqlField(
-            name: 'setPaymentWarningToUser',
-            args: {'userId': 'userId', 'state': 'state'},
-          )
+              name: 'setPaymentWarningToUser',
+              args: {'userId': 'userId', 'state': 'state'},
+            )
             ..add(GqlField(name: 'status'))
             ..add(GqlField(name: 'errors')),
         ),
@@ -895,9 +913,9 @@ abstract class User with _$User {
           name: 'lockUserAccount',
         )..add(
           GqlField(
-            name: 'lockUserAccount',
-            args: {'userId': 'userId', 'state': 'state'},
-          )
+              name: 'lockUserAccount',
+              args: {'userId': 'userId', 'state': 'state'},
+            )
             ..add(GqlField(name: 'status'))
             ..add(GqlField(name: 'errors')),
         ),
@@ -936,9 +954,9 @@ abstract class User with _$User {
           name: 'suspendUserAccount',
         )..add(
           GqlField(
-            name: 'suspendUserAccount',
-            args: {'userId': 'userId', 'state': 'state'},
-          )
+              name: 'suspendUserAccount',
+              args: {'userId': 'userId', 'state': 'state'},
+            )
             ..add(GqlField(name: 'status'))
             ..add(GqlField(name: 'errors')),
         ),
@@ -986,9 +1004,9 @@ abstract class User with _$User {
           name: 'inviteUser',
         )..add(
           GqlField(
-            name: 'inviteUser',
-            args: args,
-          )
+              name: 'inviteUser',
+              args: args,
+            )
             ..add(GqlField(name: 'status'))
             ..add(GqlField(name: 'errors'))
             ..add(GqlField(name: 'inviteLink', alias: 'result')),
@@ -1037,9 +1055,9 @@ abstract class User with _$User {
           name: 'requestActivityReport',
         )..add(
           GqlField(
-            name: 'requestActivityReport',
-            args: args,
-          )
+              name: 'requestActivityReport',
+              args: args,
+            )
             ..add(GqlField(name: 'status'))
             ..add(GqlField(name: 'errors'))
             ..add(
@@ -1062,6 +1080,7 @@ abstract class User with _$User {
       return (ApiStatus.internalError, null, null);
     }
   }
+
   // coverage:ignore-end
 }
 

--- a/lib/src/users/src/variant.dart
+++ b/lib/src/users/src/variant.dart
@@ -1,0 +1,36 @@
+part of '../users.dart';
+
+enum UserVariant {
+  /// The standard user variant, which is the default and most common variant along Layrz Appps
+  standard,
+
+  /// Dedicated to ATS, which is a variant of the user model that is used for the ATS product.
+  ats,
+
+  /// Dedicated to ATS, which is a variant of the user model that is used only for ATS Admin.
+  atsAdmin,
+
+  /// Dedicated to Brickhouse, which is a variant of the user model that is used for the Brickhouse product.
+  brickhouse,
+
+  /// Dedicated to SDM, which is a variant of the user model that is used for the SDM product.
+  sdm,
+
+  /// Dedicated to Tagon, which is a variant of the user model that is used for the Tagon product.
+  tagon,
+
+  /// Dedicated to Mappit, [mappitOperator] is the variant implemented in the Mappit ecosystem.
+  mappitOperator,
+
+  /// Dedicated to Mappit, [mappitCustomer] is the variant implemented in the Mappit ecosystem.
+  mappitCustomer,
+
+  /// Dedicated to Mappit, [mappitEmployee] is the variant implemented in the Mappit ecosystem.
+  mappitEmployee,
+
+  /// Dedicated to Mappit, [mappitSupervisor] is the variant implemented in the Mappit ecosystem.
+  mappitSupervisor,
+
+  /// Dedicated to Mappit, [mappitSeller] is the variant implemented in the Mappit ecosystem.
+  mappitSeller,
+}

--- a/lib/src/users/users.dart
+++ b/lib/src/users/users.dart
@@ -19,3 +19,4 @@ part 'src/user.dart';
 part 'src/colorblind.dart';
 part 'src/accessibility.dart';
 part 'src/preferences.dart';
+part 'src/variant.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.18.2"
+version: "3.19.0"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
## 📋 Summary

- Release `3.19.0`.
- Makes `layrz_models` the single source of truth for SDM, User and Reference API access, replacing raw GraphQL strings in the consuming packages with typed connectors.
- All connectors use the typed `connector.query` / `connector.mutate` API and header authentication.

## 📝 Changes

### ✨ Features

- **SDM** — added `SdmPenInput`, `SdmIngredientInput`, `SdmOperatorInput` and `SdmRecipeInput`, `fragment` getters for each entity, and connectors with `fetchAll`, `fetch`, `deleteMultiple` and `save`. Also added the bulk operations `bulkLoad`, `export` and `formatExcel` to `SdmPen`, `SdmIngredient` and `SdmRecipe`.
- **Users** — added the `UserVariant` enum and variant-aware connectors on `User` (`fetchAll`, `fetch`, `deleteMultiple`, and `save` on `UserInput`), resolving query, mutation and input type names per variant, with optional `appId`, `languageId` and `mappitModule` arguments. Expanded `User.fragment(variant:)` with `access`, `referencesIds`, `categoryId` and `tagsIds` plus the variant-specific fields, and added a `withDetails` option on `User.fetch`.
- **Users** — added the account actions `importIntoApp`, `resetPassword`, `setPaymentWarning`, `lock`, `suspend`, `invite` and `requestActivityReport`.
- **References** — added the `ReferenceVariant` enum and variant-aware connectors on `Reference` (`fragment(variant:)`, `fetchAll`, `fetch`, `clone`, `deleteMultiple`, and `save` on `ReferenceInput`).
- **API** — new `GqlVariableType.unix` for GraphQL `Unix` timestamp variables.

### ♻️ Refactor

- Migrated `User.fetchAll` and `User.fetchAllForAppUsers` to the typed connector API. `fetchAllForAppUsers` stays locked to the `standard` variant by design.

### 🔧 Chore / Config

- Bumped version to `3.19.0` and updated `CHANGELOG.md`.

Generated with Claude Code