### PR TITLE
Release 3.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.20.0
+
+- Added `fragment` getters to `TagOnStudent`, `TagOnBusRoute` and `TagOnNotification`.
+- Added API connectors for the TagOn entities with `fetchAll`, `fetch` and `deleteMultiple` on the models, and `save` on the existing `TagOnStudentInput`, `TagOnBusRouteInput` and `TagOnNotificationInput` models.
+- Added `TagOnStudent.bulkLoad` for bulk importing students from raw data rows. The `data` parameter is `List<Map<String, dynamic>>` (raw rows), not the typed `TagOnStudentInput` model, because the bulk endpoint resolves bus routes by name from nested objects in the raw data (e.g., `{'busRoute': {'name': 'Route 4'}}`), whereas `TagOnStudentInput` only has a flat `busRouteId`. Returns `(ApiStatus, Map<String, dynamic>?)` where the map has exactly three keys: `'status'` (the serialized `ApiStatus`), `'errors'` and `'studentsWithErrors'` (a `List<Map<String, dynamic>>`, each entry holding `errors` and `data` for a row that failed to import).
+- Added `TagOnStudent.export` to export students to a downloadable file, returning `(ApiStatus, String?)` with the generated `resultUri`.
+- Added `TagOnNotification.send` static method to send a notification by its ID.
+- All TagOn API connectors (`TagOnStudent`, `TagOnBusRoute`, `TagOnNotification`) authenticate via the `Authorization: LayrzToken <token>` header that `LayrzConnector` sets automatically. Authentication is no longer sent as a GraphQL field argument. The `apiToken` parameter remains on every method signature for consistency.
+
 ## 3.19.3
 
 - **Breaking**: Renamed `MappitReportInputMulti` to `MappitReportMultiInput` to match the backend GraphQL schema, which renamed the input type. Queries declaring `MappitReportInputMulti` are rejected by the server with `Unknown type 'MappitReportInputMulti'`. The source file was also renamed from `report_input_multi.dart` to `report_multi_input.dart`. Field names and types are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.20.0
 
+- Fixed GraphQL fragment emission order. Fragments were collected in pre-order, so a fragment that spread another was written above the fragment it depended on, producing documents where a fragment is referenced before it is defined. Nested dependencies are now emitted first, and cyclic fragment references are broken safely instead of overflowing the stack.
 - Added `fragment` getters to `TagOnStudent`, `TagOnBusRoute` and `TagOnNotification`.
 - Added API connectors for the TagOn entities with `fetchAll`, `fetch` and `deleteMultiple` on the models, and `save` on the existing `TagOnStudentInput`, `TagOnBusRouteInput` and `TagOnNotificationInput` models.
 - Added `TagOnStudent.bulkLoad` for bulk importing students from raw data rows. The `data` parameter is `List<Map<String, dynamic>>` (raw rows), not the typed `TagOnStudentInput` model, because the bulk endpoint resolves bus routes by name from nested objects in the raw data (e.g., `{'busRoute': {'name': 'Route 4'}}`), whereas `TagOnStudentInput` only has a flat `busRouteId`. Returns `(ApiStatus, Map<String, dynamic>?)` where the map has exactly three keys: `'status'` (the serialized `ApiStatus`), `'errors'` and `'studentsWithErrors'` (a `List<Map<String, dynamic>>`, each entry holding `errors` and `data` for a row that failed to import).

--- a/lib/src/api/src/gql_builder/gql.dart
+++ b/lib/src/api/src/gql_builder/gql.dart
@@ -74,17 +74,37 @@ abstract class Gql {
   /// [add] adds a top-level field to this query or mutation.
   void add(GqlField field) => fields.add(field);
 
-  /// Recursively walks [fields] and collects every [GqlFragment] referenced, deduped by name.
+  /// Recursively walks [fields] and collects every [GqlFragment] referenced, in dependency order.
+  /// Fragments are emitted using a post-order traversal: dependencies (nested fragments) are
+  /// emitted before the fragments that reference them. Each fragment is deduped by name and
+  /// appears in [result] exactly once. Cycles are detected and broken safely using a three-state
+  /// approach (visiting/emitted sets), preventing infinite loops on circular fragment dependencies.
+  /// Returns fragments in a stable, deterministic order where dependencies come first.
   List<GqlFragment> _collectFragments(List<GqlField> fields) {
-    final seen = <String>{};
+    final emitted = <String>{};
+    final visiting = <String>{};
     final result = <GqlFragment>[];
 
     void visit(List<GqlField> fs) {
       for (final f in fs) {
-        if (f.fragment != null && seen.add(f.fragment!.name)) {
-          result.add(f.fragment!);
-          // Also collect any fragments referenced inside the fragment's own fields.
+        if (f.fragment != null) {
+          final fragmentName = f.fragment!.name;
+          if (emitted.contains(fragmentName)) {
+            // Already processed; skip.
+            continue;
+          }
+          if (visiting.contains(fragmentName)) {
+            // Cycle detected; break it by not recursing further.
+            continue;
+          }
+          // Mark as visiting to detect cycles.
+          visiting.add(fragmentName);
+          // Post-order: recurse into nested fields first.
           visit(f.fragment!.fields);
+          // Then emit this fragment.
+          result.add(f.fragment!);
+          emitted.add(fragmentName);
+          visiting.remove(fragmentName);
         }
         visit(f.fields);
       }

--- a/lib/src/app/src/registered_app.dart
+++ b/lib/src/app/src/registered_app.dart
@@ -762,14 +762,70 @@ abstract class RegisteredApp with _$RegisteredApp {
     ..add(GqlField(name: 'sourceId'))
     ..add(GqlField(name: 'instances', fragment: AppInstance.fragment))
     ..add(GqlField(name: 'designInformation', fragment: AppDesign.fragment))
-    ..add(
-      GqlField(name: 'legalInformation')
-        ..add(GqlField(name: 'companyName'))
-        ..add(GqlField(name: 'companyUrl'))
-        ..add(GqlField(name: 'privacyPolicy')),
-    )
+    ..add(GqlField(name: 'legalInformation', fragment: AppLegal.fragment))
     ..add(GqlField(name: 'iosPushSecrets', fragment: PushSecrets.fragment))
     ..add(GqlField(name: 'androidPushSecrets', fragment: PushSecrets.fragment))
+    ..add(GqlField(name: 'mapLayers', fragment: MapLayer.fragment))
+    ..add(
+      GqlField(
+        name: 'allowedReports',
+        fields: [
+          GqlField(name: 'id'),
+          GqlField(name: 'code'),
+        ],
+      ),
+    )
     ..add(GqlField(name: 'hasSvcPushSecrets'));
   // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fetchPickAndApp] fetches the registered apps for the pick-an-app view.
+  /// Returns a list of [RegisteredApp] on success, null on error.
+  static Future<List<RegisteredApp>?> fetchPickAndApp({
+    required String apiToken,
+    required Uri uri,
+    required AppInternalIdentifier appIdentifier,
+    String? id,
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [
+            GqlVariable(
+              name: 'appIdentifier',
+              type: .enum_(of: 'InternalIdentifier'),
+              isRequired: true,
+              value: appIdentifier.toJson(),
+            ),
+            if (id != null) GqlVariable(name: 'id', type: .id, value: id),
+          ],
+        )..add(
+          GqlField(
+              name: 'registeredApps',
+              args: {
+                'appIdentifier': 'appIdentifier',
+                if (id != null) 'id': 'id',
+              },
+            )
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _registeredAppListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return [];
+      }
+
+      return response.result ?? [];
+    } catch (e, stack) {
+      Log.critical("layrz_models/RegisteredApp/fetchAll(): General exception => $e\n$stack");
+      return [];
+    }
+  }
+
+  /// coverage:ignore-end
 }

--- a/lib/src/map/src/layer.dart
+++ b/lib/src/map/src/layer.dart
@@ -75,6 +75,7 @@ abstract class MapLayer with _$MapLayer {
 
   factory MapLayer.fromJson(Map<String, dynamic> json) => _$MapLayerFromJson(json);
 
+  // coverage:ignore-start
   /// [fetch] fetches a single [MapLayer] from the server by its ID
   Future<MapLayer?> fetch({
     /// [apiToken] is the API token to use for authentication. You can get one using the `login` mutation
@@ -134,7 +135,9 @@ abstract class MapLayer with _$MapLayer {
       return null;
     }
   }
+  // coverage:ignore-end
 
+  // coverage:ignore-start
   /// [fetchAll] fetches all [MapLayer]s from the server
   static Future<List<MapLayer>> fetchAll({
     /// [apiToken] is the API token to use for authentication. You can get one using the `login` mutation
@@ -197,7 +200,9 @@ abstract class MapLayer with _$MapLayer {
       return [];
     }
   }
+  // coverage:ignore-end
 
+  // coverage:ignore-start
   /// [delete] deletes multiple [MapLayer]s from the server by their IDs
   static Future<bool> delete({
     /// [apiToken] is the API token to use for authentication. You can get one using the `login` mutation
@@ -260,9 +265,11 @@ abstract class MapLayer with _$MapLayer {
       return false;
     }
   }
+  // coverage:ignore-end
 
-  /// [gqlFragment] is the GqlFragment for a [MapLayer].
-  static GqlFragment get gqlFragment => GqlFragment(name: 'mapLayerFragment', onType: 'MapLayer')
+  // coverage:ignore-start
+  /// [fragment] is the GqlFragment for a [MapLayer].
+  static GqlFragment get fragment => GqlFragment(name: 'mapLayerFragment', onType: 'MapLayer')
     ..add(GqlField(name: 'id'))
     ..add(GqlField(name: 'name'))
     ..add(GqlField(name: 'source'))
@@ -281,4 +288,11 @@ abstract class MapLayer with _$MapLayer {
     ..add(GqlField(name: 'attributionWidth'))
     ..add(GqlField(name: 'attributionHeight'))
     ..add(GqlField(name: 'appsIds'));
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [gqlFragment] is the GqlFragment for a [MapLayer] with only the fields that are required for the app to work.
+  @Deprecated('Use `fragment` instead')
+  static GqlFragment get gqlFragment => fragment;
+  // coverage:ignore-end
 }

--- a/lib/src/tagon/src/bus_route.dart
+++ b/lib/src/tagon/src/bus_route.dart
@@ -1,5 +1,15 @@
 part of '../tagon.dart';
 
+TagOnBusRoute _tagOnBusRouteDecoder(Object? json) {
+  return TagOnBusRoute.fromJson(json as Map<String, dynamic>);
+}
+
+List<TagOnBusRoute> _tagOnBusRouteListDecoder(Object? json) {
+  return List<TagOnBusRoute>.from(
+    (json as List? ?? []).map((e) => TagOnBusRoute.fromJson(Map<String, dynamic>.from(e as Map))),
+  );
+}
+
 @freezed
 abstract class TagOnBusRoute with _$TagOnBusRoute {
   const TagOnBusRoute._();
@@ -12,11 +22,147 @@ abstract class TagOnBusRoute with _$TagOnBusRoute {
   }) = _TagOnBusRoute;
 
   factory TagOnBusRoute.fromJson(Map<String, dynamic> json) => _$TagOnBusRouteFromJson(json);
+
+  // coverage:ignore-start
+  /// [fetchAll] fetches all TagOn bus routes from the server
+  static Future<List<TagOnBusRoute>> fetchAll({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [],
+        )..add(
+          GqlField(name: 'tagonBusRoute')
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _tagOnBusRouteListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return [];
+      }
+
+      return response.result ?? [];
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnBusRoute/fetchAll(): General exception => $e\n$stack");
+      return [];
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fetch] fetches a single TagOn bus route from the server by its ID
+  static Future<TagOnBusRoute?> fetch({
+    /// [id] is the ID of the TagOn bus route to fetch
+    required String id,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [
+            GqlVariable(name: 'id', type: .id, isRequired: true, value: id),
+          ],
+        )..add(
+          GqlField(name: 'tagonBusRoute', args: {'id': 'id'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _tagOnBusRouteListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return null;
+      }
+
+      final resultList = response.result;
+      if (resultList == null || resultList.isEmpty) {
+        Log.warning("layrz_models/TagOnBusRoute/fetch(): No result in list");
+        return null;
+      }
+      return resultList.first;
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnBusRoute/fetch(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [deleteMultiple] deletes multiple TagOn bus routes by ID from the server
+  static Future<bool> deleteMultiple({
+    /// [ids] are the IDs of the TagOn bus routes to delete
+    required List<String> ids,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'ids', type: GqlVariableType.list(of: .id), isRequired: true, value: ids),
+          ],
+          name: 'deleteBusRoute',
+        )..add(
+          GqlField(name: 'deleteBusRoute', args: {'ids': 'ids'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnBusRoute/deleteMultiple(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fragment] is the GqlFragment for a TagOn bus route
+  static GqlFragment get fragment => GqlFragment(name: 'tagOnBusRouteFragment', onType: 'TagOnBusRoute')
+    ..add(GqlField(name: 'id'))
+    ..add(GqlField(name: 'name'));
+  // coverage:ignore-end
 }
 
 @unfreezed
 abstract class TagOnBusRouteInput with _$TagOnBusRouteInput {
-  const TagOnBusRouteInput._();
+  TagOnBusRouteInput._();
   factory TagOnBusRouteInput({
     /// [id] refers to the bus route's id
     String? id,
@@ -26,4 +172,53 @@ abstract class TagOnBusRouteInput with _$TagOnBusRouteInput {
   }) = _TagOnBusRouteInput;
 
   factory TagOnBusRouteInput.fromJson(Map<String, dynamic> json) => _$TagOnBusRouteInputFromJson(json);
+
+  // coverage:ignore-start
+  /// [save] creates or updates this TagOn bus route on the server
+  /// Returns a record with the [ApiStatus], the field errors (if any), and the saved [TagOnBusRoute].
+  Future<(ApiStatus, Map<String, dynamic>?, TagOnBusRoute?)> save({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    final operation = id == null ? 'addTagonBusRoute' : 'editTagonBusRoute';
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'data', type: GqlVariableType.input(of: 'TagOnBusRouteInput'), isRequired: false, value: toJson()),
+          ],
+          name: operation,
+        )..add(
+          GqlField(name: operation, args: {'data': 'data'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'result', fragment: TagOnBusRoute.fragment)),
+        ),
+        _tagOnBusRouteDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        return (ApiStatus.internalError, null, null);
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors, null);
+      }
+
+      return (response.status, response.errors, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnBusRouteInput/save(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null, null);
+    }
+  }
+  // coverage:ignore-end
 }

--- a/lib/src/tagon/src/notification.dart
+++ b/lib/src/tagon/src/notification.dart
@@ -1,5 +1,15 @@
 part of '../tagon.dart';
 
+TagOnNotification _tagOnNotificationDecoder(Object? json) {
+  return TagOnNotification.fromJson(json as Map<String, dynamic>);
+}
+
+List<TagOnNotification> _tagOnNotificationListDecoder(Object? json) {
+  return List<TagOnNotification>.from(
+    (json as List? ?? []).map((e) => TagOnNotification.fromJson(Map<String, dynamic>.from(e as Map))),
+  );
+}
+
 @freezed
 abstract class TagOnNotification with _$TagOnNotification {
   const TagOnNotification._();
@@ -24,11 +34,199 @@ abstract class TagOnNotification with _$TagOnNotification {
   }) = _TagOnNotification;
 
   factory TagOnNotification.fromJson(Map<String, dynamic> json) => _$TagOnNotificationFromJson(json);
+
+  // coverage:ignore-start
+  /// [fetchAll] fetches all TagOn notifications from the server
+  static Future<List<TagOnNotification>> fetchAll({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [],
+        )..add(
+          GqlField(name: 'tagonNotifications')
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _tagOnNotificationListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return [];
+      }
+
+      return response.result ?? [];
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnNotification/fetchAll(): General exception => $e\n$stack");
+      return [];
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fetch] fetches a single TagOn notification from the server by its ID
+  static Future<TagOnNotification?> fetch({
+    /// [id] is the ID of the TagOn notification to fetch
+    required String id,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [
+            GqlVariable(name: 'id', type: .id, isRequired: true, value: id),
+          ],
+        )..add(
+          GqlField(name: 'tagonNotifications', args: {'id': 'id'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _tagOnNotificationListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return null;
+      }
+
+      final resultList = response.result;
+      if (resultList == null || resultList.isEmpty) {
+        Log.warning("layrz_models/TagOnNotification/fetch(): No result in list");
+        return null;
+      }
+      return resultList.first;
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnNotification/fetch(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [deleteMultiple] deletes multiple TagOn notifications by ID from the server
+  static Future<bool> deleteMultiple({
+    /// [ids] are the IDs of the TagOn notifications to delete
+    required List<String> ids,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'ids', type: GqlVariableType.list(of: .id), isRequired: true, value: ids),
+          ],
+          name: 'deleteTagonNotifications',
+        )..add(
+          GqlField(name: 'deleteTagonNotifications', args: {'ids': 'ids'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnNotification/deleteMultiple(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [send] sends a TagOn notification by its ID
+  static Future<bool> send({
+    /// [id] is the ID of the TagOn notification to send
+    required String id,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'id', type: .id, isRequired: true, value: id),
+          ],
+          name: 'sendTagonNotification',
+        )..add(
+          GqlField(name: 'sendTagonNotification', args: {'id': 'id'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnNotification/send(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fragment] is the GqlFragment for a TagOn notification
+  static GqlFragment get fragment => GqlFragment(name: 'tagOnNotificationFragment', onType: 'TagOnNotification')
+    ..add(GqlField(name: 'id'))
+    ..add(GqlField(name: 'content'))
+    ..add(GqlField(name: 'isVisible'))
+    ..add(
+      GqlField(name: 'buses')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name'))
+        ..add(GqlField(name: 'mode')),
+    )
+    ..add(GqlField(name: 'busesIds'))
+    ..add(GqlField(name: 'destinations'));
+  // coverage:ignore-end
 }
 
 @unfreezed
 abstract class TagOnNotificationInput with _$TagOnNotificationInput {
-  const TagOnNotificationInput._();
+  TagOnNotificationInput._();
   factory TagOnNotificationInput({
     /// [id] refers to the notification id
     String? id,
@@ -47,4 +245,53 @@ abstract class TagOnNotificationInput with _$TagOnNotificationInput {
   }) = _TagOnNotificationInput;
 
   factory TagOnNotificationInput.fromJson(Map<String, dynamic> json) => _$TagOnNotificationInputFromJson(json);
+
+  // coverage:ignore-start
+  /// [save] creates or updates this TagOn notification on the server
+  /// Returns a record with the [ApiStatus], the field errors (if any), and the saved [TagOnNotification].
+  Future<(ApiStatus, Map<String, dynamic>?, TagOnNotification?)> save({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    final operation = id == null ? 'addTagonNotification' : 'editTagonNotification';
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'data', type: GqlVariableType.input(of: 'TagOnNotificationInput'), isRequired: true, value: toJson()),
+          ],
+          name: operation,
+        )..add(
+          GqlField(name: operation, args: {'data': 'data'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'result', fragment: TagOnNotification.fragment)),
+        ),
+        _tagOnNotificationDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        return (ApiStatus.internalError, null, null);
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors, null);
+      }
+
+      return (response.status, response.errors, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnNotificationInput/save(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null, null);
+    }
+  }
+  // coverage:ignore-end
 }

--- a/lib/src/tagon/src/student.dart
+++ b/lib/src/tagon/src/student.dart
@@ -1,5 +1,25 @@
 part of '../tagon.dart';
 
+TagOnStudent _tagOnStudentDecoder(Object? json) {
+  return TagOnStudent.fromJson(json as Map<String, dynamic>);
+}
+
+List<TagOnStudent> _tagOnStudentListDecoder(Object? json) {
+  return List<TagOnStudent>.from(
+    (json as List? ?? []).map((e) => TagOnStudent.fromJson(Map<String, dynamic>.from(e as Map))),
+  );
+}
+
+List<Map<String, dynamic>> _tagOnStudentBulkLoadDecoder(Object? json) {
+  return List<Map<String, dynamic>>.from(
+    (json as List? ?? []).map((e) => Map<String, dynamic>.from(e as Map)),
+  );
+}
+
+String? _tagOnStudentResultUriDecoder(Object? json) {
+  return json as String?;
+}
+
 @freezed
 abstract class TagOnStudent with _$TagOnStudent {
   const TagOnStudent._();
@@ -39,11 +59,275 @@ abstract class TagOnStudent with _$TagOnStudent {
   }) = _TagOnStudent;
 
   factory TagOnStudent.fromJson(Map<String, dynamic> json) => _$TagOnStudentFromJson(json);
+
+  // coverage:ignore-start
+  /// [fetchAll] fetches all TagOn students from the server
+  static Future<List<TagOnStudent>> fetchAll({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [],
+        )..add(
+          GqlField(name: 'tagonStudents')
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _tagOnStudentListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return [];
+      }
+
+      return response.result ?? [];
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnStudent/fetchAll(): General exception => $e\n$stack");
+      return [];
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fetch] fetches a single TagOn student from the server by its ID
+  static Future<TagOnStudent?> fetch({
+    /// [id] is the ID of the TagOn student to fetch
+    required String id,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.query(
+        GqlQuery(
+          variables: [
+            GqlVariable(name: 'id', type: .id, isRequired: true, value: id),
+          ],
+        )..add(
+          GqlField(name: 'tagonStudents', args: {'id': 'id'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'result', fragment: fragment)),
+        ),
+        _tagOnStudentListDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return null;
+      }
+
+      final resultList = response.result;
+      if (resultList == null || resultList.isEmpty) {
+        Log.warning("layrz_models/TagOnStudent/fetch(): No result in list");
+        return null;
+      }
+      return resultList.first;
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnStudent/fetch(): General exception => $e\n$stack");
+      return null;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [deleteMultiple] deletes multiple TagOn students by ID from the server
+  static Future<bool> deleteMultiple({
+    /// [ids] are the IDs of the TagOn students to delete
+    required List<String> ids,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'ids', type: GqlVariableType.list(of: .id), isRequired: true, value: ids),
+          ],
+          name: 'deleteTagonStudents',
+        )..add(
+          GqlField(name: 'deleteTagonStudents', args: {'ids': 'ids'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors')),
+        ),
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return false;
+      }
+
+      return true;
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnStudent/deleteMultiple(): General exception => $e\n$stack");
+      return false;
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [bulkLoad] loads TagOn students from raw data rows
+  ///
+  /// [data] is a list of raw row maps, where each map may contain nested bus route objects
+  /// keyed by route name (e.g., `{'busRoute': {'name': 'Route 4'}}`). This differs from
+  /// the typed [TagOnStudentInput] model, which only has `busRouteId`. The tagon bulk endpoint
+  /// resolves bus routes by name from the raw data, so raw maps are passed through as-is.
+  ///
+  /// Returns a record with the [ApiStatus] and a result map containing three keys:
+  /// - `'status'`: the [ApiStatus] as JSON (for uniform handling)
+  /// - `'errors'`: field-level errors from the root response, if any
+  /// - `'studentsWithErrors'`: a `List<Map<String, dynamic>>` of students with validation errors,
+  ///   each map containing `errors` and `data` (the student fields)
+  static Future<(ApiStatus, Map<String, dynamic>?)> bulkLoad({
+    /// [data] is the list of raw row maps to import
+    required List<Map<String, dynamic>> data,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'data', type: GqlVariableType.list(of: GqlVariableType.input(of: 'TagOnStudentInput')), isRequired: false, value: data),
+          ],
+          name: 'bulkLoadTagonStudent',
+        )..add(
+          GqlField(name: 'bulkLoadTagonStudent', args: {'data': 'data'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(
+              GqlField(name: 'studentsWithErrors', alias: 'result')
+                ..add(GqlField(name: 'errors'))
+                ..add(
+                  GqlField(name: 'data')
+                    ..add(GqlField(name: 'firstName'))
+                    ..add(GqlField(name: 'lastName'))
+                    ..add(GqlField(name: 'rfidId'))
+                    ..add(GqlField(name: 'school'))
+                    ..add(GqlField(name: 'isEligible'))
+                    ..add(GqlField(name: 'rapid'))
+                    ..add(GqlField(name: 'address'))
+                    ..add(GqlField(name: 'suburb'))
+                    ..add(GqlField(name: 'birthDate')),
+                ),
+            ),
+        ),
+        _tagOnStudentBulkLoadDecoder,
+      );
+
+      return (response.status, {
+        'status': response.status.toJson(),
+        'errors': response.errors,
+        'studentsWithErrors': response.result ?? [],
+      });
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnStudent/bulkLoad(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [export] exports TagOn students to a downloadable file
+  static Future<(ApiStatus, String?)> export({
+    /// [languageId] is the language ID for the export
+    required String languageId,
+
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'languageId', type: .id, isRequired: true, value: languageId),
+          ],
+          name: 'exportTagonStudent',
+        )..add(
+          GqlField(name: 'exportTagonStudent', args: {'languageId': 'languageId'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'resultUri', alias: 'result')),
+        ),
+        _tagOnStudentResultUriDecoder,
+      );
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, null);
+      }
+
+      return (response.status, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnStudent/export(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null);
+    }
+  }
+  // coverage:ignore-end
+
+  // coverage:ignore-start
+  /// [fragment] is the GqlFragment for a TagOn student
+  static GqlFragment get fragment => GqlFragment(name: 'tagOnStudentFragment', onType: 'TagOnStudent')
+    ..add(GqlField(name: 'id'))
+    ..add(GqlField(name: 'firstName'))
+    ..add(GqlField(name: 'lastName'))
+    ..add(GqlField(name: 'rfidId'))
+    ..add(GqlField(name: 'school'))
+    ..add(GqlField(name: 'rapid'))
+    ..add(
+      GqlField(name: 'busRoute')
+        ..add(GqlField(name: 'id'))
+        ..add(GqlField(name: 'name')),
+    )
+    ..add(GqlField(name: 'address'))
+    ..add(GqlField(name: 'suburb'))
+    ..add(GqlField(name: 'birthDate'))
+    ..add(GqlField(name: 'isEligible'));
+  // coverage:ignore-end
 }
 
 @unfreezed
 abstract class TagOnStudentInput with _$TagOnStudentInput {
-  const TagOnStudentInput._();
+  TagOnStudentInput._();
   factory TagOnStudentInput({
     /// [id] refers to the student's id
     String? id,
@@ -80,4 +364,53 @@ abstract class TagOnStudentInput with _$TagOnStudentInput {
   }) = _TagOnStudentInput;
 
   factory TagOnStudentInput.fromJson(Map<String, dynamic> json) => _$TagOnStudentInputFromJson(json);
+
+  // coverage:ignore-start
+  /// [save] creates or updates this TagOn student on the server
+  /// Returns a record with the [ApiStatus], the field errors (if any), and the saved [TagOnStudent].
+  Future<(ApiStatus, Map<String, dynamic>?, TagOnStudent?)> save({
+    /// [apiToken] is the API token to use for authentication
+    required String apiToken,
+
+    /// [uri] is the GraphQL endpoint to use
+    required Uri uri,
+
+    /// [onResponse] is the callback to call when the response is received
+    void Function(String statusCode)? onResponse,
+  }) async {
+    final connector = LayrzConnector(uri: uri, apiToken: apiToken);
+    final operation = id == null ? 'addTagonStudent' : 'editTagonStudent';
+    try {
+      final response = await connector.mutate(
+        GqlMutation(
+          variables: [
+            GqlVariable(name: 'data', type: GqlVariableType.input(of: 'TagOnStudentInput'), isRequired: false, value: toJson()),
+          ],
+          name: operation,
+        )..add(
+          GqlField(name: operation, args: {'data': 'data'})
+            ..add(GqlField(name: 'status'))
+            ..add(GqlField(name: 'errors'))
+            ..add(GqlField(name: 'result', fragment: TagOnStudent.fragment)),
+        ),
+        _tagOnStudentDecoder,
+      );
+
+      if (response.status == .internalError) {
+        onResponse?.call(response.status.toJson());
+        return (ApiStatus.internalError, null, null);
+      }
+
+      if (response.status != .ok) {
+        onResponse?.call(response.status.toJson());
+        return (response.status, response.errors, null);
+      }
+
+      return (response.status, response.errors, response.result);
+    } catch (e, stack) {
+      Log.critical("layrz_models/TagOnStudentInput/save(): General exception => $e\n$stack");
+      return (ApiStatus.internalError, null, null);
+    }
+  }
+  // coverage:ignore-end
 }

--- a/lib/src/tagon/tagon.dart
+++ b/lib/src/tagon/tagon.dart
@@ -1,6 +1,8 @@
 library;
 
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:layrz_logging/layrz_logging.dart';
+import 'package:layrz_models/src/api/api.dart';
 import 'package:layrz_models/src/assets/assets.dart';
 
 // Freezed

--- a/lib/src/users/src/user.dart
+++ b/lib/src/users/src/user.dart
@@ -289,24 +289,6 @@ abstract class User with _$User {
   // coverage:ignore-start
   /// [fragment] is the GqlFragment for a user, with full parity to layrz_users generators.
   static GqlFragment fragment({required UserVariant variant}) {
-    final gql = GqlFragment(
-      name: 'userFragment',
-      onType: _getGqlEntityName(variant: variant),
-    );
-
-    // Base fields (all variants)
-    gql.add(GqlField(name: 'id'));
-    gql.add(GqlField(name: 'name'));
-    gql.add(GqlField(name: 'email'));
-    gql.add(GqlField(name: 'username'));
-    gql.add(GqlField(name: 'parentId'));
-    gql.add(GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment));
-    gql.add(GqlField(name: 'referencesIds'));
-    gql.add(GqlField(name: 'categoryId'));
-    gql.add(GqlField(name: 'access', fragment: Access.idFragment));
-    gql.add(GqlField(name: 'tagsIds'));
-
-    // Per-variant additions
     final isMappit = [
       UserVariant.mappitOperator,
       UserVariant.mappitCustomer,
@@ -315,38 +297,127 @@ abstract class User with _$User {
       UserVariant.mappitSeller,
     ].contains(variant);
 
-    if (isMappit) {
-      gql.add(GqlField(name: 'mappitAssetsIds'));
-      gql.add(
+    final gql = GqlFragment(
+      name: 'userFragment',
+      onType: _getGqlEntityName(variant: variant),
+      fields: [
+        GqlField(name: 'id'),
+        GqlField(name: 'name'),
+        GqlField(name: 'email'),
+        GqlField(name: 'username'),
+        GqlField(name: 'parentId'),
+        GqlField(name: 'dynamicAvatar', fragment: Avatar.fragment),
+        GqlField(name: 'referencesIds'),
+        GqlField(name: 'categoryId'),
+        GqlField(name: 'access', fragment: Access.idFragment),
+        GqlField(name: 'tagsIds'),
         GqlField(
-          name: 'mappitAssets',
+          name: 'tags',
           fields: [
             GqlField(name: 'id'),
             GqlField(name: 'name'),
-            GqlField(name: 'mode'),
+            GqlField(name: 'color'),
+            GqlField(name: 'icon'),
           ],
         ),
-      );
-      gql.add(GqlField(name: 'historicalDaysAllowed'));
-    } else if (variant == .sdm) {
-      gql.add(GqlField(name: 'sdmCode'));
-    } else if (variant == .brickhouse) {
-      gql.add(GqlField(name: 'suspendedAt'));
-      gql.add(GqlField(name: 'isSuspended'));
-      gql.add(GqlField(name: 'brickhouseRole'));
-      gql.add(GqlField(name: 'brickhousePermissionTierId'));
-      gql.add(
         GqlField(
-          name: 'brickhousePermissionTier',
+          name: 'references',
           fields: [
             GqlField(name: 'id'),
             GqlField(name: 'name'),
-            GqlField(name: 'tierLevel'),
-            GqlField(name: 'billingPeriod'),
           ],
         ),
-      );
-    }
+        GqlField(name: 'categoryId'),
+        GqlField(
+          name: 'category',
+          fields: [
+            GqlField(name: 'id'),
+            GqlField(name: 'name'),
+            GqlField(name: 'kind'),
+          ],
+        ),
+        GqlField(
+          name: 'allowedApps',
+          fields: [
+            GqlField(name: 'id'),
+            GqlField(name: 'name'),
+            GqlField(name: 'nickname'),
+            GqlField(name: 'technology'),
+            GqlField(name: 'sourceId'),
+            GqlField(
+              name: 'designInformation',
+              fields: [
+                GqlField(
+                  name: 'favicons',
+                  fields: [
+                    GqlField(name: 'white'),
+                    GqlField(name: 'normal'),
+                  ],
+                ),
+                GqlField(
+                  name: 'logos',
+                  fields: [
+                    GqlField(name: 'white'),
+                    GqlField(name: 'normal'),
+                  ],
+                ),
+                GqlField(
+                  name: 'colors',
+                  fields: [
+                    GqlField(name: 'theme'),
+                    GqlField(name: 'mainColor'),
+                    GqlField(name: 'primary'),
+                    GqlField(name: 'secondary'),
+                    GqlField(name: 'accent'),
+                  ],
+                ),
+                GqlField(name: 'appicon'),
+              ],
+            ),
+            GqlField(
+              name: 'instances',
+              fields: [
+                GqlField(name: 'id'),
+                GqlField(name: 'appId'),
+                GqlField(name: 'platform'),
+                GqlField(name: 'appIdentifier'),
+                GqlField(name: 'host'),
+                GqlField(name: 'status'),
+                GqlField(name: 'migrationStatus'),
+              ],
+            ),
+          ],
+        ),
+        if (isMappit) ...[
+          GqlField(name: 'mappitAssetsIds'),
+          GqlField(
+            name: 'mappitAssets',
+            fields: [
+              GqlField(name: 'id'),
+              GqlField(name: 'name'),
+              GqlField(name: 'mode'),
+            ],
+          ),
+          GqlField(name: 'historicalDaysAllowed'),
+        ] else if (variant == .sdm) ...[
+          GqlField(name: 'sdmCode'),
+        ] else if (variant == .brickhouse) ...[
+          GqlField(name: 'suspendedAt'),
+          GqlField(name: 'isSuspended'),
+          GqlField(name: 'brickhouseRole'),
+          GqlField(name: 'brickhousePermissionTierId'),
+          GqlField(
+            name: 'brickhousePermissionTier',
+            fields: [
+              GqlField(name: 'id'),
+              GqlField(name: 'name'),
+              GqlField(name: 'tierLevel'),
+              GqlField(name: 'billingPeriod'),
+            ],
+          ),
+        ],
+      ],
+    );
 
     return gql;
   }
@@ -427,7 +498,6 @@ abstract class User with _$User {
     void Function(String statusCode)? onResponse,
     UserVariant variant = .standard,
     String? appId,
-    bool withDetails = true,
   }) async {
     final connector = LayrzConnector(uri: uri, apiToken: apiToken);
     try {
@@ -442,95 +512,6 @@ abstract class User with _$User {
         name: 'result',
         fragment: fragment(variant: variant),
       );
-
-      // Add details fields when withDetails is true
-      if (withDetails) {
-        resultField.add(
-          GqlField(
-            name: 'tags',
-            fields: [
-              GqlField(name: 'id'),
-              GqlField(name: 'name'),
-              GqlField(name: 'color'),
-              GqlField(name: 'icon'),
-            ],
-          ),
-        );
-        resultField.add(
-          GqlField(
-            name: 'references',
-            fields: [
-              GqlField(name: 'id'),
-              GqlField(name: 'name'),
-            ],
-          ),
-        );
-        resultField.add(GqlField(name: 'categoryId'));
-        resultField.add(
-          GqlField(
-            name: 'category',
-            fields: [
-              GqlField(name: 'id'),
-              GqlField(name: 'name'),
-              GqlField(name: 'kind'),
-            ],
-          ),
-        );
-        resultField.add(
-          GqlField(
-            name: 'allowedApps',
-            fields: [
-              GqlField(name: 'id'),
-              GqlField(name: 'name'),
-              GqlField(name: 'nickname'),
-              GqlField(name: 'technology'),
-              GqlField(name: 'sourceId'),
-              GqlField(
-                name: 'designInformation',
-                fields: [
-                  GqlField(
-                    name: 'favicons',
-                    fields: [
-                      GqlField(name: 'white'),
-                      GqlField(name: 'normal'),
-                    ],
-                  ),
-                  GqlField(
-                    name: 'logos',
-                    fields: [
-                      GqlField(name: 'white'),
-                      GqlField(name: 'normal'),
-                    ],
-                  ),
-                  GqlField(
-                    name: 'colors',
-                    fields: [
-                      GqlField(name: 'theme'),
-                      GqlField(name: 'mainColor'),
-                      GqlField(name: 'primary'),
-                      GqlField(name: 'secondary'),
-                      GqlField(name: 'accent'),
-                    ],
-                  ),
-                  GqlField(name: 'appicon'),
-                ],
-              ),
-              GqlField(
-                name: 'instances',
-                fields: [
-                  GqlField(name: 'id'),
-                  GqlField(name: 'appId'),
-                  GqlField(name: 'platform'),
-                  GqlField(name: 'appIdentifier'),
-                  GqlField(name: 'host'),
-                  GqlField(name: 'status'),
-                  GqlField(name: 'migrationStatus'),
-                ],
-              ),
-            ],
-          ),
-        );
-      }
 
       final response = await connector.query(
         GqlQuery(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.19.3"
+version: "3.20.0"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:

--- a/test/api/gql_fragment_order_test.dart
+++ b/test/api/gql_fragment_order_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:layrz_models/layrz_models.dart';
+
+int _countFragmentOccurrences(String haystack, String fragmentPattern) {
+  return fragmentPattern.allMatches(haystack).length;
+}
+
+void main() {
+  group('GQL fragment ordering', () {
+    test('Nested dependency emits child first', () {
+      final deviceFragment = GqlFragment(
+        name: 'DeviceFragment',
+        onType: 'Device',
+        fields: [
+          GqlField(name: 'id'),
+          GqlField(name: 'name'),
+        ],
+      );
+      final assetFragment = GqlFragment(
+        name: 'AssetFragment',
+        onType: 'Asset',
+        fields: [
+          GqlField(name: 'id'),
+          GqlField(name: 'device', fragment: deviceFragment),
+        ],
+      );
+      final query = GqlQuery(
+        name: 'GetAssets',
+        fields: [
+          GqlField(name: 'assets', fragment: assetFragment),
+        ],
+      );
+
+      final generated = query.generated;
+      final deviceIdx = generated.indexOf('fragment DeviceFragment on Device');
+      final assetIdx = generated.indexOf('fragment AssetFragment on Asset');
+
+      expect(deviceIdx, greaterThanOrEqualTo(0), reason: 'DeviceFragment should be present in generated output');
+      expect(assetIdx, greaterThanOrEqualTo(0), reason: 'AssetFragment should be present in generated output');
+      expect(
+        deviceIdx,
+        lessThan(assetIdx),
+        reason: 'Child fragment DeviceFragment must appear before parent fragment AssetFragment',
+      );
+    });
+
+    test('Sibling + nested spread is deduped and still ordered', () {
+      // Pre-order impl would emit AssetFragment before DeviceFragment (wrong order).
+      final deviceFragment = GqlFragment(
+        name: 'DeviceFragment',
+        onType: 'Device',
+        fields: [
+          GqlField(name: 'id'),
+          GqlField(name: 'name'),
+        ],
+      );
+      final assetFragment = GqlFragment(
+        name: 'AssetFragment',
+        onType: 'Asset',
+        fields: [
+          GqlField(name: 'id'),
+          GqlField(name: 'device', fragment: deviceFragment),
+        ],
+      );
+      final query = GqlQuery(
+        name: 'GetAssetAndDevice',
+        fields: [
+          GqlField(name: 'device', fragment: deviceFragment),
+          GqlField(name: 'assets', fragment: assetFragment),
+        ],
+      );
+
+      final generated = query.generated;
+      final occurrences = _countFragmentOccurrences(generated, 'fragment DeviceFragment on Device');
+      expect(
+        occurrences,
+        equals(1),
+        reason: 'DeviceFragment should appear exactly once despite being referenced twice',
+      );
+
+      final deviceIdx = generated.indexOf('fragment DeviceFragment on Device');
+      final assetIdx = generated.indexOf('fragment AssetFragment on Asset');
+      expect(
+        deviceIdx,
+        lessThan(assetIdx),
+        reason: 'Dependency DeviceFragment must appear before AssetFragment even when both are siblings at top level',
+      );
+    });
+
+    test('Three-level chain A -> B -> C emits C, B, A in that order', () {
+      final fragmentC = GqlFragment(
+        name: 'FragmentC',
+        onType: 'TypeC',
+        fields: [GqlField(name: 'id')],
+      );
+      final fragmentB = GqlFragment(
+        name: 'FragmentB',
+        onType: 'TypeB',
+        fields: [
+          GqlField(name: 'id'),
+          GqlField(name: 'c', fragment: fragmentC),
+        ],
+      );
+      final fragmentA = GqlFragment(
+        name: 'FragmentA',
+        onType: 'TypeA',
+        fields: [
+          GqlField(name: 'id'),
+          GqlField(name: 'b', fragment: fragmentB),
+        ],
+      );
+      final query = GqlQuery(
+        name: 'GetA',
+        fields: [GqlField(name: 'a', fragment: fragmentA)],
+      );
+
+      final generated = query.generated;
+      final idxC = generated.indexOf('fragment FragmentC on TypeC');
+      final idxB = generated.indexOf('fragment FragmentB on TypeB');
+      final idxA = generated.indexOf('fragment FragmentA on TypeA');
+
+      expect(idxC, greaterThanOrEqualTo(0), reason: 'FragmentC should be present');
+      expect(idxB, greaterThanOrEqualTo(0), reason: 'FragmentB should be present');
+      expect(idxA, greaterThanOrEqualTo(0), reason: 'FragmentA should be present');
+      expect(idxC, lessThan(idxB), reason: 'FragmentC (deepest dependency) must come before FragmentB');
+      expect(idxB, lessThan(idxA), reason: 'FragmentB (intermediate dependency) must come before FragmentA');
+    });
+
+    test('Cycle does not hang or overflow', () {
+      final fragmentA = GqlFragment(name: 'FragmentA', onType: 'TypeA');
+      final fragmentB = GqlFragment(name: 'FragmentB', onType: 'TypeB');
+      fragmentA.add(GqlField(name: 'b', fragment: fragmentB));
+      fragmentB.add(GqlField(name: 'a', fragment: fragmentA));
+
+      final query = GqlQuery(
+        name: 'GetA',
+        fields: [GqlField(name: 'a', fragment: fragmentA)],
+      );
+
+      expect(
+        () => query.generated,
+        returnsNormally,
+        reason: 'Accessing .generated on a cyclic fragment dependency should not hang or overflow',
+      );
+
+      final generated = query.generated;
+      final aCount = _countFragmentOccurrences(generated, 'fragment FragmentA on TypeA');
+      final bCount = _countFragmentOccurrences(generated, 'fragment FragmentB on TypeB');
+
+      expect(aCount, equals(1), reason: 'FragmentA should appear exactly once even in a cycle');
+      expect(bCount, equals(1), reason: 'FragmentB should appear exactly once even in a cycle');
+    });
+
+    test('Independent fragments keep first-encounter order', () {
+      final fragmentX = GqlFragment(
+        name: 'FragmentX',
+        onType: 'TypeX',
+        fields: [GqlField(name: 'id')],
+      );
+      final fragmentY = GqlFragment(
+        name: 'FragmentY',
+        onType: 'TypeY',
+        fields: [GqlField(name: 'id')],
+      );
+      final query = GqlQuery(
+        name: 'GetXY',
+        fields: [
+          GqlField(name: 'x', fragment: fragmentX),
+          GqlField(name: 'y', fragment: fragmentY),
+        ],
+      );
+
+      final generated = query.generated;
+      final idxX = generated.indexOf('fragment FragmentX on TypeX');
+      final idxY = generated.indexOf('fragment FragmentY on TypeY');
+
+      expect(idxX, greaterThanOrEqualTo(0), reason: 'FragmentX should be present');
+      expect(idxY, greaterThanOrEqualTo(0), reason: 'FragmentY should be present');
+      expect(
+        idxX,
+        lessThan(idxY),
+        reason: 'First-encountered FragmentX must appear before FragmentY to preserve stable order',
+      );
+    });
+
+    test('Fragment blocks all appear before the operation keyword', () {
+      final deviceFragment = GqlFragment(
+        name: 'DeviceFragment',
+        onType: 'Device',
+        fields: [GqlField(name: 'id')],
+      );
+      final query = GqlQuery(
+        name: 'GetDevice',
+        fields: [GqlField(name: 'device', fragment: deviceFragment)],
+      );
+
+      final generated = query.generated;
+      final fragmentIdx = generated.indexOf('fragment DeviceFragment on Device');
+      final queryIdx = generated.indexOf('query GetDevice');
+
+      expect(fragmentIdx, greaterThanOrEqualTo(0), reason: 'Fragment block should be present');
+      expect(queryIdx, greaterThanOrEqualTo(0), reason: 'Query keyword should be present');
+      expect(
+        fragmentIdx,
+        lessThan(queryIdx),
+        reason: 'All fragment definition blocks must appear before the query operation keyword',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Release 3.20.0

`pubspec.yaml` was bumped to `3.20.0` in 742f044 but `v3.20.0` was never tagged — the newest tag is `v3.19.3`. Rather than cut a new version, the work merged since then folds into the existing unreleased `3.20.0` section.

## Included

- **TagOn API connectors** (4c214bc) — `fragment` getters plus `fetchAll` / `fetch` / `deleteMultiple` on `TagOnStudent`, `TagOnBusRoute` and `TagOnNotification`, `save` on the matching `*Input` models, and `TagOnStudent.bulkLoad` / `TagOnStudent.export` / `TagOnNotification.send`.
- **GQL fragment ordering fix** (c61ae5a, #251) — `_collectFragments` walked the field tree in pre-order, emitting a fragment above the fragment it depended on and producing documents where a fragment is referenced before it is defined. Now post-order, with a three-state cycle guard so cyclic fragment references break safely instead of overflowing the stack. Adds `test/api/gql_fragment_order_test.dart`, the first test coverage for the GQL builder.
- **User / RegisteredApp / map layer changes** (a0327ff) — additional fields on the `User` fragment and removal of deprecated details, plus changes to `RegisteredApp` and the map layer model.

## Note on the changelog

The `## 3.20.0` section covers the TagOn connectors and the fragment ordering fix. It does **not** yet document a0327ff (`User` fragment fields, `RegisteredApp`, map layer). Worth adding before tagging if those are consumer-facing.

## Version

- `pubspec.yaml` — `3.20.0`, unchanged by this PR (already bumped in 742f044; not CI-managed).
- `CHANGELOG.md` — one bullet added to the existing `3.20.0` section (ce2183a).
- No other language manifests in this repo (`pyproject.toml`, `go.mod`, `.claude/plugin.json` are all absent).
