### PR TITLE
feat(ats): add saleFromThirdPartyDeliveredBySeller purchase-order category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.25.0
+
+- Added `saleFromThirdPartyDeliveredBySeller` value to `AtsPurchaseOrderCategoriesEntity` enum (`SALE_FROM_THIRD_PARTY_DELIVERED_BY_SELLER`, CFOP 5120/6120), so it no longer falls back to `notDefined`.
+
 ## 3.24.7
 
 - Added `hasPreviousStockClosing` value in `StockClosingInfoPa` model

--- a/lib/src/ats/ats.g.dart
+++ b/lib/src/ats/ats.g.dart
@@ -1632,6 +1632,8 @@ const _$AtsPurchaseOrderCategoriesEntityEnumMap = {
       'PRODUCTION_SALE_TO_FREE_TRADE_ZONE',
   AtsPurchaseOrderCategoriesEntity.saleFromThirdPartyTank:
       'SALE_FROM_THIRD_PARTY_TANK',
+  AtsPurchaseOrderCategoriesEntity.saleFromThirdPartyDeliveredBySeller:
+      'SALE_FROM_THIRD_PARTY_DELIVERED_BY_SELLER',
   AtsPurchaseOrderCategoriesEntity.notDefined: 'NOT_DEFINED',
   AtsPurchaseOrderCategoriesEntity.remittanceSale: 'REMITTANCE_SALE',
 };

--- a/lib/src/ats/src/enums/purchase_order_categories_entity.dart
+++ b/lib/src/ats/src/enums/purchase_order_categories_entity.dart
@@ -32,6 +32,9 @@ enum AtsPurchaseOrderCategoriesEntity {
   // Venda de tanque de terceiros (5106 / 6106)
   @JsonValue('SALE_FROM_THIRD_PARTY_TANK')
   saleFromThirdPartyTank,
+  // Venda de tanque de terceiros entregue pelo vendedor (5120 / 6120)
+  @JsonValue('SALE_FROM_THIRD_PARTY_DELIVERED_BY_SELLER')
+  saleFromThirdPartyDeliveredBySeller,
   // Not defined
   @JsonValue('NOT_DEFINED')
   notDefined,
@@ -63,6 +66,9 @@ enum AtsPurchaseOrderCategoriesEntity {
       case '5659':
       case '6659':
         return AtsPurchaseOrderCategoriesEntity.transfer;
+      case '5120':
+      case '6120':
+        return AtsPurchaseOrderCategoriesEntity.saleFromThirdPartyDeliveredBySeller;
       case '5656':
       case '6656':
         return AtsPurchaseOrderCategoriesEntity.deliveryToSupplier;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.24.7"
+version: "3.25.0"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:


### PR DESCRIPTION
## Problem

The backend sends purchase orders with `category: "SALE_FROM_THIRD_PARTY_DELIVERED_BY_SELLER"` (CFOP 5120/6120). This value did not exist in `AtsPurchaseOrderCategoriesEntity`, so `fromJson` fell back to `notDefined`. Reception flows in `ats_mobile` treat `notDefined` as non-receivable, which **silently hid valid operations** from the terminal reception list (e.g. operations 119341, 119347).

## Change

- Add `saleFromThirdPartyDeliveredBySeller` enum value with `@JsonValue('SALE_FROM_THIRD_PARTY_DELIVERED_BY_SELLER')`.
- Map CFOP `5120`/`6120` to it in `AtsPurchaseOrderCategoriesEntity.cfop()`.
- Regenerate `ats.g.dart` (build_runner).
- Bump version `3.24.7` -> `3.25.0` and update CHANGELOG.

## Verification

Verified end-to-end in `ats_mobile` (via a local path override) on asset **ABI - PORTO VELHO (52155)**: the affected operations now produce a receivable group and appear in the terminal reception list. The remessa NFe (CFOP 6923) is still correctly skipped.

## Notes

- Non-breaking, additive change → minor bump.
- Tag `v3.25.0` will be created **after** this PR is approved and merged.