### PR TITLE
fix: correct GraphQL call sites for device commands, Device deletes and Zigbee key (3.24.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.24.8
+
+- Corrected `CommandInput.save()`, the `status`/`errors`/`result` selection now hangs off the `addDeviceCommand`/`editDeviceCommand` mutation field instead of the mutation root
+- Corrected `DeviceCommand.execute()`, the mutation field is `executeDeviceCommand` and not `deviceCommands`
+- Corrected `Device.zigbeePermitJoinExpiresAt`, removed the snake_case `JsonKey` that never matched the fragment field and always decoded to null
+- Corrected `Device.delete()`, `Device.deleteMany()` and `Device.importDevicesIntoApp()` to be sent as mutations, plus the field is `importDevicesIntoApp` and not `importDevicesToApp`
+- Added `InboundProtocol.detailedFragment`, which is `fragment` plus the protocol's `models`, and used it on `InboundProtocol.fetch()`
+
 ## 3.24.7
 
 - Added `hasPreviousStockClosing` value in `StockClosingInfoPa` model

--- a/lib/src/commands/src/command_input.dart
+++ b/lib/src/commands/src/command_input.dart
@@ -62,10 +62,11 @@ abstract class CommandInput with _$CommandInput {
     ValueChanged<ApiStatus>? onResponse,
   }) async {
     final connector = LayrzConnector(apiToken: apiToken, uri: uri);
+    final mutationName = id == null ? 'addDeviceCommand' : 'editDeviceCommand';
     try {
       final response = await connector.mutate(
         GqlMutation(
-          name: id == null ? 'addDeviceCommand' : 'editDeviceCommand',
+          name: mutationName,
           variables: [
             GqlVariable(
               name: 'data',
@@ -74,10 +75,19 @@ abstract class CommandInput with _$CommandInput {
               isRequired: true,
             ),
           ],
+          // status/errors/result hang off the mutation field, not off the mutation root:
+          // selecting them directly builds `mutation addDeviceCommand { status ... }`, which
+          // never invokes the mutation and fails while resolving the nested fragments.
           fields: [
-            GqlField(name: 'status'),
-            GqlField(name: 'errors'),
-            GqlField(name: 'result', fragment: DeviceCommand.fragment),
+            GqlField(
+              name: mutationName,
+              args: {'data': 'data'},
+              fields: [
+                GqlField(name: 'status'),
+                GqlField(name: 'errors'),
+                GqlField(name: 'result', fragment: DeviceCommand.fragment),
+              ],
+            ),
           ],
         ),
         _deviceCommandDecoder,

--- a/lib/src/commands/src/device_command.dart
+++ b/lib/src/commands/src/device_command.dart
@@ -424,7 +424,9 @@ abstract class DeviceCommand with _$DeviceCommand {
           ],
           fields: [
             GqlField(
-              name: 'deviceCommands',
+              // The mutation field is `executeDeviceCommand`; `deviceCommands` is the
+              // read query used by [fetch]/[fetchAll] and does not exist on the mutation root.
+              name: 'executeDeviceCommand',
               args: {
                 'commandId': 'commandId',
                 if (deviceId != null) 'deviceId': 'deviceId',

--- a/lib/src/devices/devices.freezed.dart
+++ b/lib/src/devices/devices.freezed.dart
@@ -51,7 +51,10 @@ mixin _$Device {
  bool? get hasWorldwideCoverage;/// Auto-generated Zigbee zone ID (10 chars). Empty for non-Zigbee devices.
  String get zigbeeZoneId;/// Auto-generated Zigbee token (72 chars). Empty for non-Zigbee devices.
  String get zigbeeToken;/// When permit-join expires on the Zigbee coordinator. Null if not active.
-@JsonKey(name: 'zigbee_permit_join_expires_at') DateTime? get zigbeePermitJoinExpiresAt;
+///
+/// The key matches the field name: the fragment requests `zigbeePermitJoinExpiresAt`,
+/// so a snake_case [JsonKey] would never match and would decode to null forever.
+ DateTime? get zigbeePermitJoinExpiresAt;
 /// Create a copy of Device
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -84,7 +87,7 @@ abstract mixin class $DeviceCopyWith<$Res>  {
   factory $DeviceCopyWith(Device value, $Res Function(Device) _then) = _$DeviceCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, String ident, String? flespiToken, String? modelId, Model? model, String? protocolId, InboundProtocol? protocol, Map<String, dynamic>? additionalFields, String? qrCode, String? linkQr, List<DeviceCommand>? commands, List<Access>? access, DeviceTelemetry? telemetry, String? visionProfileId, VisionProfile? visionProfile, PhoneNumber? phone, ModbusConfig? modbus, bool? isSuspended, HwModel? hwModel, String? hwModelId, String? macAddress, Map<String, dynamic>? configParams,@DurationConverter() Duration? visionCaptureThreshold, List<Device>? peripherals, List<ZigbeeDevice>? zigbeeDevices, List<ZigbeeDeviceExpose>? exposes, String? localIpAddress, bool? hasWorldwideCoverage, String zigbeeZoneId, String zigbeeToken,@JsonKey(name: 'zigbee_permit_join_expires_at') DateTime? zigbeePermitJoinExpiresAt
+ String id, String name, String ident, String? flespiToken, String? modelId, Model? model, String? protocolId, InboundProtocol? protocol, Map<String, dynamic>? additionalFields, String? qrCode, String? linkQr, List<DeviceCommand>? commands, List<Access>? access, DeviceTelemetry? telemetry, String? visionProfileId, VisionProfile? visionProfile, PhoneNumber? phone, ModbusConfig? modbus, bool? isSuspended, HwModel? hwModel, String? hwModelId, String? macAddress, Map<String, dynamic>? configParams,@DurationConverter() Duration? visionCaptureThreshold, List<Device>? peripherals, List<ZigbeeDevice>? zigbeeDevices, List<ZigbeeDeviceExpose>? exposes, String? localIpAddress, bool? hasWorldwideCoverage, String zigbeeZoneId, String zigbeeToken, DateTime? zigbeePermitJoinExpiresAt
 });
 
 
@@ -304,7 +307,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String ident,  String? flespiToken,  String? modelId,  Model? model,  String? protocolId,  InboundProtocol? protocol,  Map<String, dynamic>? additionalFields,  String? qrCode,  String? linkQr,  List<DeviceCommand>? commands,  List<Access>? access,  DeviceTelemetry? telemetry,  String? visionProfileId,  VisionProfile? visionProfile,  PhoneNumber? phone,  ModbusConfig? modbus,  bool? isSuspended,  HwModel? hwModel,  String? hwModelId,  String? macAddress,  Map<String, dynamic>? configParams, @DurationConverter()  Duration? visionCaptureThreshold,  List<Device>? peripherals,  List<ZigbeeDevice>? zigbeeDevices,  List<ZigbeeDeviceExpose>? exposes,  String? localIpAddress,  bool? hasWorldwideCoverage,  String zigbeeZoneId,  String zigbeeToken, @JsonKey(name: 'zigbee_permit_join_expires_at')  DateTime? zigbeePermitJoinExpiresAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String ident,  String? flespiToken,  String? modelId,  Model? model,  String? protocolId,  InboundProtocol? protocol,  Map<String, dynamic>? additionalFields,  String? qrCode,  String? linkQr,  List<DeviceCommand>? commands,  List<Access>? access,  DeviceTelemetry? telemetry,  String? visionProfileId,  VisionProfile? visionProfile,  PhoneNumber? phone,  ModbusConfig? modbus,  bool? isSuspended,  HwModel? hwModel,  String? hwModelId,  String? macAddress,  Map<String, dynamic>? configParams, @DurationConverter()  Duration? visionCaptureThreshold,  List<Device>? peripherals,  List<ZigbeeDevice>? zigbeeDevices,  List<ZigbeeDeviceExpose>? exposes,  String? localIpAddress,  bool? hasWorldwideCoverage,  String zigbeeZoneId,  String zigbeeToken,  DateTime? zigbeePermitJoinExpiresAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Device() when $default != null:
 return $default(_that.id,_that.name,_that.ident,_that.flespiToken,_that.modelId,_that.model,_that.protocolId,_that.protocol,_that.additionalFields,_that.qrCode,_that.linkQr,_that.commands,_that.access,_that.telemetry,_that.visionProfileId,_that.visionProfile,_that.phone,_that.modbus,_that.isSuspended,_that.hwModel,_that.hwModelId,_that.macAddress,_that.configParams,_that.visionCaptureThreshold,_that.peripherals,_that.zigbeeDevices,_that.exposes,_that.localIpAddress,_that.hasWorldwideCoverage,_that.zigbeeZoneId,_that.zigbeeToken,_that.zigbeePermitJoinExpiresAt);case _:
@@ -325,7 +328,7 @@ return $default(_that.id,_that.name,_that.ident,_that.flespiToken,_that.modelId,
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String ident,  String? flespiToken,  String? modelId,  Model? model,  String? protocolId,  InboundProtocol? protocol,  Map<String, dynamic>? additionalFields,  String? qrCode,  String? linkQr,  List<DeviceCommand>? commands,  List<Access>? access,  DeviceTelemetry? telemetry,  String? visionProfileId,  VisionProfile? visionProfile,  PhoneNumber? phone,  ModbusConfig? modbus,  bool? isSuspended,  HwModel? hwModel,  String? hwModelId,  String? macAddress,  Map<String, dynamic>? configParams, @DurationConverter()  Duration? visionCaptureThreshold,  List<Device>? peripherals,  List<ZigbeeDevice>? zigbeeDevices,  List<ZigbeeDeviceExpose>? exposes,  String? localIpAddress,  bool? hasWorldwideCoverage,  String zigbeeZoneId,  String zigbeeToken, @JsonKey(name: 'zigbee_permit_join_expires_at')  DateTime? zigbeePermitJoinExpiresAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String ident,  String? flespiToken,  String? modelId,  Model? model,  String? protocolId,  InboundProtocol? protocol,  Map<String, dynamic>? additionalFields,  String? qrCode,  String? linkQr,  List<DeviceCommand>? commands,  List<Access>? access,  DeviceTelemetry? telemetry,  String? visionProfileId,  VisionProfile? visionProfile,  PhoneNumber? phone,  ModbusConfig? modbus,  bool? isSuspended,  HwModel? hwModel,  String? hwModelId,  String? macAddress,  Map<String, dynamic>? configParams, @DurationConverter()  Duration? visionCaptureThreshold,  List<Device>? peripherals,  List<ZigbeeDevice>? zigbeeDevices,  List<ZigbeeDeviceExpose>? exposes,  String? localIpAddress,  bool? hasWorldwideCoverage,  String zigbeeZoneId,  String zigbeeToken,  DateTime? zigbeePermitJoinExpiresAt)  $default,) {final _that = this;
 switch (_that) {
 case _Device():
 return $default(_that.id,_that.name,_that.ident,_that.flespiToken,_that.modelId,_that.model,_that.protocolId,_that.protocol,_that.additionalFields,_that.qrCode,_that.linkQr,_that.commands,_that.access,_that.telemetry,_that.visionProfileId,_that.visionProfile,_that.phone,_that.modbus,_that.isSuspended,_that.hwModel,_that.hwModelId,_that.macAddress,_that.configParams,_that.visionCaptureThreshold,_that.peripherals,_that.zigbeeDevices,_that.exposes,_that.localIpAddress,_that.hasWorldwideCoverage,_that.zigbeeZoneId,_that.zigbeeToken,_that.zigbeePermitJoinExpiresAt);case _:
@@ -345,7 +348,7 @@ return $default(_that.id,_that.name,_that.ident,_that.flespiToken,_that.modelId,
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String ident,  String? flespiToken,  String? modelId,  Model? model,  String? protocolId,  InboundProtocol? protocol,  Map<String, dynamic>? additionalFields,  String? qrCode,  String? linkQr,  List<DeviceCommand>? commands,  List<Access>? access,  DeviceTelemetry? telemetry,  String? visionProfileId,  VisionProfile? visionProfile,  PhoneNumber? phone,  ModbusConfig? modbus,  bool? isSuspended,  HwModel? hwModel,  String? hwModelId,  String? macAddress,  Map<String, dynamic>? configParams, @DurationConverter()  Duration? visionCaptureThreshold,  List<Device>? peripherals,  List<ZigbeeDevice>? zigbeeDevices,  List<ZigbeeDeviceExpose>? exposes,  String? localIpAddress,  bool? hasWorldwideCoverage,  String zigbeeZoneId,  String zigbeeToken, @JsonKey(name: 'zigbee_permit_join_expires_at')  DateTime? zigbeePermitJoinExpiresAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String ident,  String? flespiToken,  String? modelId,  Model? model,  String? protocolId,  InboundProtocol? protocol,  Map<String, dynamic>? additionalFields,  String? qrCode,  String? linkQr,  List<DeviceCommand>? commands,  List<Access>? access,  DeviceTelemetry? telemetry,  String? visionProfileId,  VisionProfile? visionProfile,  PhoneNumber? phone,  ModbusConfig? modbus,  bool? isSuspended,  HwModel? hwModel,  String? hwModelId,  String? macAddress,  Map<String, dynamic>? configParams, @DurationConverter()  Duration? visionCaptureThreshold,  List<Device>? peripherals,  List<ZigbeeDevice>? zigbeeDevices,  List<ZigbeeDeviceExpose>? exposes,  String? localIpAddress,  bool? hasWorldwideCoverage,  String zigbeeZoneId,  String zigbeeToken,  DateTime? zigbeePermitJoinExpiresAt)?  $default,) {final _that = this;
 switch (_that) {
 case _Device() when $default != null:
 return $default(_that.id,_that.name,_that.ident,_that.flespiToken,_that.modelId,_that.model,_that.protocolId,_that.protocol,_that.additionalFields,_that.qrCode,_that.linkQr,_that.commands,_that.access,_that.telemetry,_that.visionProfileId,_that.visionProfile,_that.phone,_that.modbus,_that.isSuspended,_that.hwModel,_that.hwModelId,_that.macAddress,_that.configParams,_that.visionCaptureThreshold,_that.peripherals,_that.zigbeeDevices,_that.exposes,_that.localIpAddress,_that.hasWorldwideCoverage,_that.zigbeeZoneId,_that.zigbeeToken,_that.zigbeePermitJoinExpiresAt);case _:
@@ -360,7 +363,7 @@ return $default(_that.id,_that.name,_that.ident,_that.flespiToken,_that.modelId,
 @JsonSerializable()
 
 class _Device extends Device {
-  const _Device({required this.id, required this.name, required this.ident, this.flespiToken, this.modelId, this.model, this.protocolId, this.protocol, final  Map<String, dynamic>? additionalFields, this.qrCode, this.linkQr, final  List<DeviceCommand>? commands, final  List<Access>? access, this.telemetry, this.visionProfileId, this.visionProfile, this.phone, this.modbus, this.isSuspended, this.hwModel, this.hwModelId, this.macAddress, final  Map<String, dynamic>? configParams, @DurationConverter() this.visionCaptureThreshold, final  List<Device>? peripherals, final  List<ZigbeeDevice>? zigbeeDevices, final  List<ZigbeeDeviceExpose>? exposes, this.localIpAddress, this.hasWorldwideCoverage, this.zigbeeZoneId = '', this.zigbeeToken = '', @JsonKey(name: 'zigbee_permit_join_expires_at') this.zigbeePermitJoinExpiresAt}): _additionalFields = additionalFields,_commands = commands,_access = access,_configParams = configParams,_peripherals = peripherals,_zigbeeDevices = zigbeeDevices,_exposes = exposes,super._();
+  const _Device({required this.id, required this.name, required this.ident, this.flespiToken, this.modelId, this.model, this.protocolId, this.protocol, final  Map<String, dynamic>? additionalFields, this.qrCode, this.linkQr, final  List<DeviceCommand>? commands, final  List<Access>? access, this.telemetry, this.visionProfileId, this.visionProfile, this.phone, this.modbus, this.isSuspended, this.hwModel, this.hwModelId, this.macAddress, final  Map<String, dynamic>? configParams, @DurationConverter() this.visionCaptureThreshold, final  List<Device>? peripherals, final  List<ZigbeeDevice>? zigbeeDevices, final  List<ZigbeeDeviceExpose>? exposes, this.localIpAddress, this.hasWorldwideCoverage, this.zigbeeZoneId = '', this.zigbeeToken = '', this.zigbeePermitJoinExpiresAt}): _additionalFields = additionalFields,_commands = commands,_access = access,_configParams = configParams,_peripherals = peripherals,_zigbeeDevices = zigbeeDevices,_exposes = exposes,super._();
   factory _Device.fromJson(Map<String, dynamic> json) => _$DeviceFromJson(json);
 
 @override final  String id;
@@ -496,7 +499,10 @@ class _Device extends Device {
 /// Auto-generated Zigbee token (72 chars). Empty for non-Zigbee devices.
 @override@JsonKey() final  String zigbeeToken;
 /// When permit-join expires on the Zigbee coordinator. Null if not active.
-@override@JsonKey(name: 'zigbee_permit_join_expires_at') final  DateTime? zigbeePermitJoinExpiresAt;
+///
+/// The key matches the field name: the fragment requests `zigbeePermitJoinExpiresAt`,
+/// so a snake_case [JsonKey] would never match and would decode to null forever.
+@override final  DateTime? zigbeePermitJoinExpiresAt;
 
 /// Create a copy of Device
 /// with the given fields replaced by the non-null parameter values.
@@ -531,7 +537,7 @@ abstract mixin class _$DeviceCopyWith<$Res> implements $DeviceCopyWith<$Res> {
   factory _$DeviceCopyWith(_Device value, $Res Function(_Device) _then) = __$DeviceCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, String ident, String? flespiToken, String? modelId, Model? model, String? protocolId, InboundProtocol? protocol, Map<String, dynamic>? additionalFields, String? qrCode, String? linkQr, List<DeviceCommand>? commands, List<Access>? access, DeviceTelemetry? telemetry, String? visionProfileId, VisionProfile? visionProfile, PhoneNumber? phone, ModbusConfig? modbus, bool? isSuspended, HwModel? hwModel, String? hwModelId, String? macAddress, Map<String, dynamic>? configParams,@DurationConverter() Duration? visionCaptureThreshold, List<Device>? peripherals, List<ZigbeeDevice>? zigbeeDevices, List<ZigbeeDeviceExpose>? exposes, String? localIpAddress, bool? hasWorldwideCoverage, String zigbeeZoneId, String zigbeeToken,@JsonKey(name: 'zigbee_permit_join_expires_at') DateTime? zigbeePermitJoinExpiresAt
+ String id, String name, String ident, String? flespiToken, String? modelId, Model? model, String? protocolId, InboundProtocol? protocol, Map<String, dynamic>? additionalFields, String? qrCode, String? linkQr, List<DeviceCommand>? commands, List<Access>? access, DeviceTelemetry? telemetry, String? visionProfileId, VisionProfile? visionProfile, PhoneNumber? phone, ModbusConfig? modbus, bool? isSuspended, HwModel? hwModel, String? hwModelId, String? macAddress, Map<String, dynamic>? configParams,@DurationConverter() Duration? visionCaptureThreshold, List<Device>? peripherals, List<ZigbeeDevice>? zigbeeDevices, List<ZigbeeDeviceExpose>? exposes, String? localIpAddress, bool? hasWorldwideCoverage, String zigbeeZoneId, String zigbeeToken, DateTime? zigbeePermitJoinExpiresAt
 });
 
 

--- a/lib/src/devices/devices.g.dart
+++ b/lib/src/devices/devices.g.dart
@@ -65,9 +65,9 @@ _Device _$DeviceFromJson(Map<String, dynamic> json) => _Device(
   hasWorldwideCoverage: json['hasWorldwideCoverage'] as bool?,
   zigbeeZoneId: json['zigbeeZoneId'] as String? ?? '',
   zigbeeToken: json['zigbeeToken'] as String? ?? '',
-  zigbeePermitJoinExpiresAt: json['zigbee_permit_join_expires_at'] == null
+  zigbeePermitJoinExpiresAt: json['zigbeePermitJoinExpiresAt'] == null
       ? null
-      : DateTime.parse(json['zigbee_permit_join_expires_at'] as String),
+      : DateTime.parse(json['zigbeePermitJoinExpiresAt'] as String),
 );
 
 Map<String, dynamic> _$DeviceToJson(_Device instance) => <String, dynamic>{
@@ -105,7 +105,7 @@ Map<String, dynamic> _$DeviceToJson(_Device instance) => <String, dynamic>{
   'hasWorldwideCoverage': instance.hasWorldwideCoverage,
   'zigbeeZoneId': instance.zigbeeZoneId,
   'zigbeeToken': instance.zigbeeToken,
-  'zigbee_permit_join_expires_at': instance.zigbeePermitJoinExpiresAt
+  'zigbeePermitJoinExpiresAt': instance.zigbeePermitJoinExpiresAt
       ?.toIso8601String(),
 };
 

--- a/lib/src/devices/src/device.dart
+++ b/lib/src/devices/src/device.dart
@@ -102,7 +102,10 @@ abstract class Device with _$Device {
     @Default('') String zigbeeToken,
 
     /// When permit-join expires on the Zigbee coordinator. Null if not active.
-    @JsonKey(name: 'zigbee_permit_join_expires_at') DateTime? zigbeePermitJoinExpiresAt,
+    ///
+    /// The key matches the field name: the fragment requests `zigbeePermitJoinExpiresAt`,
+    /// so a snake_case [JsonKey] would never match and would decode to null forever.
+    DateTime? zigbeePermitJoinExpiresAt,
   }) = _Device;
 
   factory Device.fromJson(Map<String, dynamic> json) => _$DeviceFromJson(json);
@@ -360,8 +363,10 @@ abstract class Device with _$Device {
   }) async {
     final connector = LayrzConnector(uri: uri, apiToken: apiToken);
     try {
-      final response = await connector.query(
-        GqlQuery(
+      // [deleteDevices] lives on the mutation root, so this must go out as a mutation:
+      // sending it as a query fails with `Cannot query field "deleteDevices" on type "Query"`.
+      final response = await connector.mutate(
+        GqlMutation(
           name: _getDeleteMutationNameFromVariant(variant),
           variables: [
             GqlVariable(
@@ -422,8 +427,10 @@ abstract class Device with _$Device {
   }) async {
     final connector = LayrzConnector(uri: uri, apiToken: apiToken);
     try {
-      final response = await connector.query(
-        GqlQuery(
+      // [deleteDevices] lives on the mutation root, so this must go out as a mutation:
+      // sending it as a query fails with `Cannot query field "deleteDevices" on type "Query"`.
+      final response = await connector.mutate(
+        GqlMutation(
           name: _getDeleteMutationNameFromVariant(variant),
           variables: [
             GqlVariable(
@@ -597,9 +604,11 @@ abstract class Device with _$Device {
   }) async {
     final connector = LayrzConnector(uri: uri, apiToken: apiToken);
     try {
-      final response = await connector.query(
-        GqlQuery(
-          name: 'importDevicesToApp',
+      // Mutation root, and the field is `importDevicesIntoApp` — `importDevicesToApp`
+      // does not exist in the schema. See [RegisteredApp.importDevicesIntoApp].
+      final response = await connector.mutate(
+        GqlMutation(
+          name: 'importDevicesIntoApp',
           variables: [
             GqlVariable(name: 'appId', value: appId, type: .id, isRequired: true),
             GqlVariable(
@@ -611,7 +620,7 @@ abstract class Device with _$Device {
           ],
         )..add(
           GqlField(
-            name: 'importDevicesToApp',
+            name: 'importDevicesIntoApp',
             args: {
               'appId': 'appId',
               'devicesIds': 'devicesIds',

--- a/lib/src/inbound/src/protocol.dart
+++ b/lib/src/inbound/src/protocol.dart
@@ -177,6 +177,23 @@ abstract class InboundProtocol with _$InboundProtocol {
   // coverage:ignore-end
 
   // coverage:ignore-start
+  /// [detailedFragment] is [fragment] plus the protocol's [models].
+  ///
+  /// Consumers that resolve a model out of `protocol.models` need them present — the command
+  /// form in `layrz_commands` does exactly that, and with the plain [fragment] the lookup
+  /// silently yields null and the form never renders. Kept separate from [fragment] so the
+  /// protocol *listing* is not forced to carry every model of every protocol.
+  static GqlFragment get detailedFragment => GqlFragment(
+    name: 'InboundProtocolFragment',
+    onType: 'InboundProtocol',
+    fields: [
+      ...fragment.fields,
+      GqlField(name: 'models', fragment: Model.reducedFragment),
+    ],
+  );
+  // coverage:ignore-end
+
+  // coverage:ignore-start
   /// [reducedFragment] is an small fragment of the protocol, used to identify the protocol in the system.
   static GqlFragment get reducedFragment => GqlFragment(
     name: 'InboundProtocolFragment',
@@ -299,7 +316,7 @@ abstract class InboundProtocol with _$InboundProtocol {
               args: {'id': 'id'},
               fields: [
                 GqlField(name: 'status'),
-                GqlField(name: 'result', fragment: fragment),
+                GqlField(name: 'result', fragment: detailedFragment),
               ],
             ),
           ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 description: Layrz API models for Dart/Flutter. This package contains the models
   used by the Layrz API.
 name: layrz_models
-version: "3.24.7"
+version: "3.24.8"
 repository: https://github.com/goldenm-software/layrz_models
 
 environment:

--- a/test/device/device_test.dart
+++ b/test/device/device_test.dart
@@ -227,12 +227,12 @@ void main() {
       expect(device.peripherals![1].id, 'device_peripheral_2');
     });
 
-    test('Device.fromJson() with zigbee_permit_join_expires_at (snake_case)', () {
+    test('Device.fromJson() with zigbeePermitJoinExpiresAt', () {
       final json = <String, dynamic>{
         'id': 'device_zigbee',
         'name': 'Zigbee Device',
         'ident': 'ZIGBEE_001',
-        'zigbee_permit_join_expires_at': '2026-07-22T10:30:00Z',
+        'zigbeePermitJoinExpiresAt': '2026-07-22T10:30:00Z',
       };
 
       final device = Device.fromJson(json);
@@ -241,7 +241,7 @@ void main() {
       expect(device.zigbeePermitJoinExpiresAt, isA<DateTime>());
     });
 
-    test('Device.toJson() preserves zigbee_permit_join_expires_at as snake_case key', () {
+    test('Device.toJson() preserves zigbeePermitJoinExpiresAt key', () {
       final device = Device(
         id: 'device_zb_key',
         name: 'Zigbee Key Test',
@@ -251,7 +251,7 @@ void main() {
 
       final json = device.toJson();
 
-      expect(json['zigbee_permit_join_expires_at'], isNotNull);
+      expect(json['zigbeePermitJoinExpiresAt'], isNotNull);
     });
 
     test('Device defaults for zigbeeZoneId and zigbeeToken', () {


### PR DESCRIPTION
## Summary

Fixes a set of GraphQL call-site bugs that were failing silently, and adds a detailed fragment for `InboundProtocol`. Releases `3.24.8`.

## Changes

- **`CommandInput.save()`** — `status`/`errors`/`result` now hang off the `addDeviceCommand`/`editDeviceCommand` mutation field instead of the mutation root. Selecting them at the root built `mutation addDeviceCommand { status ... }`, which never invoked the mutation and failed while resolving the nested fragments.
- **`DeviceCommand.execute()`** — the mutation field is `executeDeviceCommand`; `deviceCommands` is the read query used by `fetch()`/`fetchAll()` and does not exist on the mutation root.
- **`Device.zigbeePermitJoinExpiresAt`** — dropped the snake_case `@JsonKey`. The fragment requests `zigbeePermitJoinExpiresAt`, so the key never matched and the field always decoded to `null`.
- **`Device.delete()` / `Device.deleteMany()` / `Device.importDevicesIntoApp()`** — sent as mutations via `connector.mutate` + `GqlMutation`; as queries they failed with `Cannot query field "deleteDevices" on type "Query"`. Also, the field is `importDevicesIntoApp`, not `importDevicesToApp`.
- **`InboundProtocol.detailedFragment`** — new fragment (`fragment` + the protocol's `models`), used by `fetch()`. Consumers that resolve a model out of `protocol.models` (the command form in `layrz_commands`) got `null` with the plain fragment and never rendered.

## Notes

- Two `device_test.dart` cases asserted the old snake_case key and were updated to camelCase.
- Version bumped to `3.24.8` with the corresponding CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
